### PR TITLE
Centralize default port configuration

### DIFF
--- a/cmd/glyph/main.go
+++ b/cmd/glyph/main.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/glyphlang/glyph/pkg/compiler"
+	"github.com/glyphlang/glyph/pkg/config"
 	glyphcontext "github.com/glyphlang/glyph/pkg/context"
 	"github.com/glyphlang/glyph/pkg/decompiler"
 	"github.com/glyphlang/glyph/pkg/formatter"
@@ -84,7 +85,7 @@ to rapidly build high-performance, secure backend applications.`,
 		Args:  cobra.ExactArgs(1),
 		RunE:  runRun,
 	}
-	runCmd.Flags().Uint16P("port", "p", 3000, "Port to listen on")
+	runCmd.Flags().Uint16P("port", "p", uint16(config.DefaultPort), "Port to listen on")
 	runCmd.Flags().Bool("bytecode", false, "Execute bytecode (.glyphc) file")
 	runCmd.Flags().Bool("interpret", false, "Use tree-walking interpreter instead of compiler (fallback mode)")
 
@@ -95,7 +96,7 @@ to rapidly build high-performance, secure backend applications.`,
 		Args:  cobra.ExactArgs(1),
 		RunE:  runDev,
 	}
-	devCmd.Flags().Uint16P("port", "p", 3000, "Port to listen on")
+	devCmd.Flags().Uint16P("port", "p", uint16(config.DefaultPort), "Port to listen on")
 	devCmd.Flags().BoolP("watch", "w", true, "Watch for file changes")
 	devCmd.Flags().BoolP("open", "o", false, "Open browser automatically")
 

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -1,0 +1,6 @@
+// Package config provides shared configuration constants for GlyphLang.
+package config
+
+// DefaultPort is the default port for the GlyphLang HTTP server.
+// Used by both the CLI and server package to ensure consistency.
+const DefaultPort = 3000

--- a/pkg/hotreload/watcher.go
+++ b/pkg/hotreload/watcher.go
@@ -13,6 +13,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/glyphlang/glyph/pkg/config"
 )
 
 // ========================================
@@ -627,7 +629,7 @@ type DevServerConfig struct {
 func DefaultDevServerConfig() DevServerConfig {
 	return DevServerConfig{
 		WatchPaths:   []string{"."},
-		Port:         8080,
+		Port:         config.DefaultPort,
 		Host:         "localhost",
 		LiveReload:   true,
 		OpenBrowser:  false,

--- a/pkg/hotreload/watcher_test.go
+++ b/pkg/hotreload/watcher_test.go
@@ -7,6 +7,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/glyphlang/glyph/pkg/config"
 )
 
 func TestFileWatcher_MatchesPattern(t *testing.T) {
@@ -303,21 +305,21 @@ func TestLiveReloadScript(t *testing.T) {
 }
 
 func TestDefaultDevServerConfig(t *testing.T) {
-	config := DefaultDevServerConfig()
+	cfg := DefaultDevServerConfig()
 
-	if config.Port != 8080 {
-		t.Errorf("Expected port 8080, got %d", config.Port)
+	if cfg.Port != config.DefaultPort {
+		t.Errorf("Expected port %d, got %d", config.DefaultPort, cfg.Port)
 	}
 
-	if config.Host != "localhost" {
-		t.Errorf("Expected host localhost, got %s", config.Host)
+	if cfg.Host != "localhost" {
+		t.Errorf("Expected host localhost, got %s", cfg.Host)
 	}
 
-	if !config.LiveReload {
+	if !cfg.LiveReload {
 		t.Error("Expected LiveReload to be true")
 	}
 
-	if len(config.WatchPaths) == 0 {
+	if len(cfg.WatchPaths) == 0 {
 		t.Error("Expected at least one watch path")
 	}
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/glyphlang/glyph/pkg/config"
 	ws "github.com/glyphlang/glyph/pkg/websocket"
 )
 
@@ -29,7 +30,7 @@ func NewServer(options ...ServerOption) *Server {
 	s := &Server{
 		router:      NewRouter(),
 		middlewares: make([]Middleware, 0),
-		addr:        ":8080",
+		addr:        fmt.Sprintf(":%d", config.DefaultPort),
 		wsServer:    ws.NewServer(), // Initialize WebSocket server
 	}
 


### PR DESCRIPTION
- Add pkg/config package with DefaultPort constant (3000)
- Update pkg/server, pkg/hotreload, and cmd/glyph to use the shared constant
- Single source of truth eliminates sync issues between components

## Description

<!-- Briefly describe your changes -->

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

## Testing

<!-- Describe how you tested your changes -->

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [x] My code follows the project's coding style
- [x] I have tested my changes
- [x] I have updated documentation if needed

## Contributor License Agreement

- [x] I agree to the Contributor License Agreement as described in [CONTRIBUTING.md](../CONTRIBUTING.md). I confirm that I have the right to submit this contribution and grant the project maintainers the rights described therein, including the right to relicense my contributions.
