### PR TITLE
docs: Add contributor guides and community resources

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,146 @@
+# GlyphLang GitHub Labels Configuration
+# Use with github-label-sync: npx github-label-sync --labels .github/labels.yml owner/repo
+#
+# To apply these labels to your repository:
+#   npm install -g github-label-sync
+#   github-label-sync --access-token YOUR_TOKEN --labels .github/labels.yml GlyphLang/GlyphLang
+
+# =============================================================================
+# Contributor Labels
+# =============================================================================
+
+- name: good-first-issue
+  color: "7057ff"
+  description: Good for newcomers to the project
+
+- name: help-wanted
+  color: "008672"
+  description: Extra attention is needed from the community
+
+# =============================================================================
+# Difficulty Labels
+# =============================================================================
+
+- name: "difficulty:beginner"
+  color: "c2e0c6"
+  description: Suitable for contributors new to the codebase
+
+- name: "difficulty:intermediate"
+  color: "fbca04"
+  description: Requires familiarity with the codebase
+
+- name: "difficulty:advanced"
+  color: "d93f0b"
+  description: Requires deep knowledge of the system architecture
+
+# =============================================================================
+# Area Labels
+# =============================================================================
+
+- name: "area:parser"
+  color: "0052cc"
+  description: Related to the parser and syntax analysis
+
+- name: "area:compiler"
+  color: "0052cc"
+  description: Related to the compiler and code generation
+
+- name: "area:vm"
+  color: "0052cc"
+  description: Related to the virtual machine
+
+- name: "area:interpreter"
+  color: "0052cc"
+  description: Related to the interpreter
+
+- name: "area:server"
+  color: "0052cc"
+  description: Related to the Glyph server
+
+- name: "area:lsp"
+  color: "0052cc"
+  description: Related to the Language Server Protocol implementation
+
+- name: "area:cli"
+  color: "0052cc"
+  description: Related to the command-line interface
+
+- name: "area:database"
+  color: "0052cc"
+  description: Related to database functionality
+
+- name: "area:security"
+  color: "0052cc"
+  description: Related to security features and concerns
+
+- name: "area:docs"
+  color: "0052cc"
+  description: Related to documentation
+
+# =============================================================================
+# Type Labels
+# =============================================================================
+
+- name: "type:bug"
+  color: "d73a4a"
+  description: Something is not working as expected
+
+- name: "type:feature"
+  color: "a2eeef"
+  description: New functionality or capability
+
+- name: "type:enhancement"
+  color: "a2eeef"
+  description: Improvement to existing functionality
+
+- name: "type:refactor"
+  color: "c5def5"
+  description: Code restructuring without behavior change
+
+- name: "type:test"
+  color: "c5def5"
+  description: Adding or improving tests
+
+- name: "type:performance"
+  color: "f9d0c4"
+  description: Performance improvement or optimization
+
+# =============================================================================
+# Priority Labels
+# =============================================================================
+
+- name: "priority:low"
+  color: "c5def5"
+  description: Nice to have but not urgent
+
+- name: "priority:medium"
+  color: "fbca04"
+  description: Should be addressed in the near term
+
+- name: "priority:high"
+  color: "ff7619"
+  description: Important issue requiring prompt attention
+
+- name: "priority:critical"
+  color: "b60205"
+  description: Must be addressed immediately
+
+# =============================================================================
+# Status Labels
+# =============================================================================
+
+- name: "status:blocked"
+  color: "d93f0b"
+  description: Blocked by another issue or external factor
+
+- name: "status:needs-info"
+  color: "d876e3"
+  description: Requires more information from reporter
+
+- name: "status:in-progress"
+  color: "0e8a16"
+  description: Currently being worked on
+
+- name: "status:ready"
+  color: "0e8a16"
+  description: Ready to be worked on

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,90 @@
+
+# Contributor Covenant 3.0 Code of Conduct
+
+## Our Pledge
+
+We pledge to make our community welcoming, safe, and equitable for all.
+
+We are committed to fostering an environment that respects and promotes the dignity, rights, and contributions of all individuals, regardless of characteristics including race, ethnicity, caste, color, age, physical characteristics, neurodiversity, disability, sex or gender, gender identity or expression, sexual orientation, language, philosophy or religion, national or social origin, socio-economic position, level of education, or other status. The same privileges of participation are extended to everyone who participates in good faith and in accordance with this Covenant.
+
+
+## Encouraged Behaviors
+
+While acknowledging differences in social norms, we all strive to meet our community's expectations for positive behavior. We also understand that our words and actions may be interpreted differently than we intend based on culture, background, or native language.
+
+With these considerations in mind, we agree to behave mindfully toward each other and act in ways that center our shared values, including:
+
+1. Respecting the **purpose of our community**, our activities, and our ways of gathering.
+2. Engaging **kindly and honestly** with others.
+3. Respecting **different viewpoints** and experiences.
+4. **Taking responsibility** for our actions and contributions.
+5. Gracefully giving and accepting **constructive feedback**.
+6. Committing to **repairing harm** when it occurs.
+7. Behaving in other ways that promote and sustain the **well-being of our community**.
+
+
+## Restricted Behaviors
+
+We agree to restrict the following behaviors in our community. Instances, threats, and promotion of these behaviors are violations of this Code of Conduct.
+
+1. **Harassment.** Violating explicitly expressed boundaries or engaging in unnecessary personal attention after any clear request to stop.
+2. **Character attacks.** Making insulting, demeaning, or pejorative comments directed at a community member or group of people.
+3. **Stereotyping or discrimination.** Characterizing anyone’s personality or behavior on the basis of immutable identities or traits.
+4. **Sexualization.** Behaving in a way that would generally be considered inappropriately intimate in the context or purpose of the community.
+5. **Violating confidentiality**. Sharing or acting on someone's personal or private information without their permission.
+6. **Endangerment.** Causing, encouraging, or threatening violence or other harm toward any person or group.
+7. Behaving in other ways that **threaten the well-being** of our community.
+
+### Other Restrictions
+
+1. **Misleading identity.** Impersonating someone else for any reason, or pretending to be someone else to evade enforcement actions.
+2. **Failing to credit sources.** Not properly crediting the sources of content you contribute.
+3. **Promotional materials**. Sharing marketing or other commercial content in a way that is outside the norms of the community.
+4. **Irresponsible communication.** Failing to responsibly present content which includes, links or describes any other restricted behaviors.
+
+
+## Reporting an Issue
+
+Tensions can occur between community members even when they are trying their best to collaborate. Not every conflict represents a code of conduct violation, and this Code of Conduct reinforces encouraged behaviors and norms that can help avoid conflicts and minimize harm.
+
+When an incident does occur, it is important to report it promptly. To report a possible violation, send an email describing the incident to conduct@glyphlang.dev.
+
+Community Moderators take reports of violations seriously and will make every effort to respond in a timely manner. They will investigate all reports of code of conduct violations, reviewing messages, logs, and recordings, or interviewing witnesses and other participants. Community Moderators will keep investigation and enforcement actions as transparent as possible while prioritizing safety and confidentiality. In order to honor these values, enforcement actions are carried out in private with the involved parties, but communicating to the whole community may be part of a mutually agreed upon resolution.
+
+
+## Addressing and Repairing Harm
+
+If an investigation by the Community Moderators finds that this Code of Conduct has been violated, the following enforcement ladder may be used to determine how best to repair harm, based on the incident's impact on the individuals involved and the community as a whole. Depending on the severity of a violation, lower rungs on the ladder may be skipped.
+
+1) Warning
+   1) Event: A violation involving a single incident or series of incidents.
+   2) Consequence: A private, written warning from the Community Moderators.
+   3) Repair: Examples of repair include a private written apology, acknowledgement of responsibility, and seeking clarification on expectations.
+2) Temporarily Limited Activities
+   1) Event: A repeated incidence of a violation that previously resulted in a warning, or the first incidence of a more serious violation.
+   2) Consequence: A private, written warning with a time-limited cooldown period designed to underscore the seriousness of the situation and give the community members involved time to process the incident. The cooldown period may be limited to particular communication channels or interactions with particular community members.
+   3) Repair: Examples of repair may include making an apology, using the cooldown period to reflect on actions and impact, and being thoughtful about re-entering community spaces after the period is over.
+3) Temporary Suspension
+   1) Event: A pattern of repeated violation which the Community Moderators have tried to address with warnings, or a single serious violation.
+   2) Consequence: A private written warning with conditions for return from suspension. In general, temporary suspensions give the person being suspended time to reflect upon their behavior and possible corrective actions.
+   3) Repair: Examples of repair include respecting the spirit of the suspension, meeting the specified conditions for return, and being thoughtful about how to reintegrate with the community when the suspension is lifted.
+4) Permanent Ban
+   1) Event: A pattern of repeated code of conduct violations that other steps on the ladder have failed to resolve, or a violation so serious that the Community Moderators determine there is no way to keep the community safe with this person as a member.
+   2) Consequence: Access to all community spaces, tools, and communication channels is removed. In general, permanent bans should be rarely used, should have strong reasoning behind them, and should only be resorted to if working through other remedies has failed to change the behavior.
+   3) Repair: There is no possible repair in cases of this severity.
+
+This enforcement ladder is intended as a guideline. It does not limit the ability of Community Managers to use their discretion and judgment, in keeping with the best interests of our community.
+
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public or other spaces. Examples of representing our community include using an official email address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+
+## Attribution
+
+This Code of Conduct is adapted from the Contributor Covenant, version 3.0, permanently available at [https://www.contributor-covenant.org/version/3/0/](https://www.contributor-covenant.org/version/3/0/).
+
+Contributor Covenant is stewarded by the Organization for Ethical Source and licensed under CC BY-SA 4.0. To view a copy of this license, visit [https://creativecommons.org/licenses/by-sa/4.0/](https://creativecommons.org/licenses/by-sa/4.0/)
+
+For answers to common questions about Contributor Covenant, see the FAQ at [https://www.contributor-covenant.org/faq](https://www.contributor-covenant.org/faq). Translations are provided at [https://www.contributor-covenant.org/translations](https://www.contributor-covenant.org/translations). Additional enforcement and community guideline resources can be found at [https://www.contributor-covenant.org/resources](https://www.contributor-covenant.org/resources). The enforcement ladder was inspired by the work of [Mozilla’s code of conduct team](https://github.com/mozilla/inclusion).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,7 @@ Thank you for your interest in contributing to GlyphLang! This document outlines
 - [Commit Messages](#commit-messages)
 - [Pull Requests](#pull-requests)
 - [Reporting Issues](#reporting-issues)
+- [Issue Labels](#issue-labels)
 - [Feature Requests](#feature-requests)
 - [Contributor License Agreement](#contributor-license-agreement)
 - [Code of Conduct](#code-of-conduct)
@@ -239,6 +240,90 @@ When reporting bugs, include:
 ### Security Issues
 
 For security vulnerabilities, please do NOT open a public issue. Instead, email the maintainers directly or use GitHub's private security reporting feature.
+
+## Issue Labels
+
+We use a structured labeling system to help contributors find appropriate work and to track issue status. You can filter issues by labels on the GitHub Issues page.
+
+### Finding Issues by Skill Level
+
+**New to GlyphLang?** Start with these labels:
+
+- `good-first-issue` - Issues specifically curated for newcomers. These typically have clear requirements, limited scope, and include guidance on where to start.
+- `difficulty:beginner` - Issues that require minimal familiarity with the codebase.
+
+**Ready for more?** Look for:
+
+- `difficulty:intermediate` - Issues that require familiarity with the codebase structure and conventions.
+- `help-wanted` - Issues where maintainers are actively seeking community contributions.
+
+**Experienced contributors** can tackle:
+
+- `difficulty:advanced` - Complex issues requiring deep knowledge of the system architecture.
+
+### Label Categories
+
+#### Type Labels
+
+Indicate what kind of work the issue involves:
+
+| Label | Description |
+|-------|-------------|
+| `type:bug` | Something is not working as expected |
+| `type:feature` | New functionality or capability |
+| `type:enhancement` | Improvement to existing functionality |
+| `type:refactor` | Code restructuring without behavior change |
+| `type:test` | Adding or improving tests |
+| `type:performance` | Performance improvement or optimization |
+
+#### Area Labels
+
+Indicate which part of the codebase is affected:
+
+| Label | Description |
+|-------|-------------|
+| `area:parser` | Parser and syntax analysis |
+| `area:compiler` | Compiler and code generation |
+| `area:vm` | Virtual machine |
+| `area:interpreter` | Interpreter |
+| `area:server` | Glyph server |
+| `area:lsp` | Language Server Protocol implementation |
+| `area:cli` | Command-line interface |
+| `area:database` | Database functionality |
+| `area:security` | Security features and concerns |
+| `area:docs` | Documentation |
+
+#### Priority Labels
+
+Indicate urgency:
+
+| Label | Description |
+|-------|-------------|
+| `priority:low` | Nice to have but not urgent |
+| `priority:medium` | Should be addressed in the near term |
+| `priority:high` | Important issue requiring prompt attention |
+| `priority:critical` | Must be addressed immediately |
+
+#### Status Labels
+
+Indicate current state:
+
+| Label | Description |
+|-------|-------------|
+| `status:ready` | Ready to be worked on |
+| `status:in-progress` | Currently being worked on |
+| `status:blocked` | Blocked by another issue or external factor |
+| `status:needs-info` | Requires more information from reporter |
+
+### Tips for Contributors
+
+1. **Combine filters** - Use multiple labels to find the perfect issue. For example, filter by `good-first-issue` AND `area:parser` to find beginner-friendly parser issues.
+
+2. **Check status first** - Look for `status:ready` issues that are not already assigned.
+
+3. **Comment before starting** - Leave a comment on the issue to let maintainers know you are working on it. This prevents duplicate effort.
+
+4. **Ask questions** - If an issue is unclear, add a comment asking for clarification rather than guessing.
 
 ## Feature Requests
 

--- a/README.md
+++ b/README.md
@@ -595,6 +595,17 @@ GlyphLang/
 └── tests/               # Integration tests
 ```
 
+## Community and Support
+
+We welcome questions, feedback, and contributions from the community.
+
+**Get Help and Connect:**
+- [GitHub Discussions](https://github.com/GlyphLang/GlyphLang/discussions) - Ask questions, share ideas, and discuss GlyphLang
+- [GitHub Issues](https://github.com/GlyphLang/GlyphLang/issues) - Report bugs or request features
+- [Contributing Guide](CONTRIBUTING.md) - Learn how to contribute to the project
+
+Whether you are just getting started or have experience with GlyphLang, we encourage you to participate. No question is too small, and your feedback helps make GlyphLang better for everyone.
+
 ## Contributing
 
 Contributions welcome! Please read [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.

--- a/docs/FIRST_CONTRIBUTION.md
+++ b/docs/FIRST_CONTRIBUTION.md
@@ -1,0 +1,175 @@
+# Your First Contribution to GlyphLang
+
+Welcome to the GlyphLang project! This guide will help you make your first contribution. We are excited to have you join our community.
+
+## Finding Your First Issue
+
+Look for issues labeled `good-first-issue` in our GitHub repository:
+
+1. Go to [github.com/GlyphLang/GlyphLang/issues](https://github.com/GlyphLang/GlyphLang/issues)
+2. Filter by the `good-first-issue` label
+3. Comment on the issue to let maintainers know you want to work on it
+4. Wait for assignment before starting work
+
+Good first issues typically involve documentation fixes, adding test cases, improving error messages, or small bug fixes.
+
+---
+
+## Understanding the Codebase
+
+GlyphLang is written in Go and follows a modular architecture. Here is an overview of the main packages:
+
+### pkg/parser - Lexer and Parser
+
+Handles the first stage of compilation. The lexer tokenizes source code and the parser builds an Abstract Syntax Tree (AST). Good for learning about language design.
+
+### pkg/compiler - Bytecode Compiler
+
+Transforms the AST into bytecode with multiple optimization levels (0-3). Handles constant folding and dead code elimination.
+
+### pkg/vm - Virtual Machine
+
+A stack-based VM that executes compiled bytecode. Manages memory, implements all opcodes, and handles garbage collection.
+
+### pkg/interpreter - AST Interpreter
+
+An alternative execution mode that walks the AST directly. Easier to understand than bytecode execution and useful for debugging.
+
+### pkg/server - HTTP Server
+
+Handles HTTP routing, middleware chains, request/response handling, and WebSocket support.
+
+### pkg/lsp - Language Server Protocol
+
+Provides IDE features: code completion, go-to-definition, error diagnostics, and hover information.
+
+### pkg/database - Database Integration
+
+Handles PostgreSQL operations: connection pooling, query execution, transactions, and ORM-like operations.
+
+---
+
+## Beginner-Friendly Areas
+
+Not sure where to start? These areas are welcoming to newcomers:
+
+### Documentation Improvements
+- Fix typos or unclear explanations in `docs/` or package READMEs
+- Add examples to existing documentation
+- Update outdated information
+
+### Adding Test Cases
+- Add tests for edge cases in any package
+- Improve test coverage with table-driven tests
+- Test error conditions and failure modes
+
+Run tests with: `go test ./...`
+
+### Parser Error Messages
+- Improve error message clarity in `pkg/parser/` and `pkg/errors/`
+- Add suggestions for common mistakes
+- Include better context in syntax errors
+
+### CLI Improvements
+- Improve help text in `cmd/glyph/`
+- Add better error messages for invalid arguments
+- Enhance output formatting
+
+---
+
+## Step-by-Step: Your First PR
+
+### 1. Fork and Clone
+
+```bash
+git clone https://github.com/YOUR_USERNAME/GlyphLang.git
+cd GlyphLang
+git remote add upstream https://github.com/GlyphLang/GlyphLang.git
+```
+
+### 2. Set Up Your Environment
+
+```bash
+go mod tidy
+go build -o glyph ./cmd/glyph
+./glyph version
+```
+
+### 3. Create a Branch
+
+Always branch from main:
+
+```bash
+git fetch upstream
+git checkout main
+git merge upstream/main
+git checkout -b feature/your-feature-name
+```
+
+### 4. Make Your Changes
+
+- Follow existing code style
+- Run `gofmt` to format your code
+- Add tests for new functionality
+
+### 5. Run Tests
+
+```bash
+go test ./...
+go vet ./...
+```
+
+### 6. Commit and Push
+
+```bash
+git add .
+git commit -m "fix: improve error message for missing semicolon"
+git push origin feature/your-feature-name
+```
+
+Use prefixes: `feat:`, `fix:`, `docs:`, `test:`, `refactor:`
+
+### 7. Create the Pull Request
+
+1. Go to GitHub and click "Compare & pull request"
+2. Fill in the PR template with a clear description
+3. Reference related issues (e.g., "Fixes #123")
+4. Submit and respond to reviewer feedback
+
+---
+
+## Getting Help
+
+### Ask in Your PR
+If you have questions while working, ask in the PR comments. Maintainers are happy to help.
+
+### Open a Discussion
+For general questions, use the Discussions tab on GitHub.
+
+### Review Existing Resources
+- [CONTRIBUTING.md](../CONTRIBUTING.md) - Detailed contribution guidelines
+- [docs/ARCHITECTURE_DESIGN.md](ARCHITECTURE_DESIGN.md) - System architecture
+- [docs/LANGUAGE_SPECIFICATION.md](LANGUAGE_SPECIFICATION.md) - Language syntax
+
+### Tips for Getting Help
+- Describe what you are trying to accomplish
+- Share what you have already tried
+- Include relevant error messages or code snippets
+
+---
+
+## What to Expect
+
+After submitting your PR:
+
+1. **Automated checks**: CI runs tests and linting
+2. **CLA signature**: Sign the Contributor License Agreement
+3. **Code review**: A maintainer reviews your changes
+4. **Feedback**: You may receive requests for changes
+5. **Merge**: Once approved, your PR is merged
+
+Reviews typically take a few days. Feel free to ping the PR if you have not heard back in a week.
+
+---
+
+Thank you for contributing to GlyphLang! Every contribution helps make the project better. We look forward to your first PR.


### PR DESCRIPTION
Add Code of Conduct, first contribution guide, GitHub issue labels, and community support section to improve contributor onboarding.

## Description

<!-- Briefly describe your changes -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Other (please describe)

## Testing

<!-- Describe how you tested your changes -->

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [x] My code follows the project's coding style
- [x] I have tested my changes
- [x] I have updated documentation if needed

## Contributor License Agreement

- [ ] I agree to the Contributor License Agreement as described in [CONTRIBUTING.md](../CONTRIBUTING.md). I confirm that I have the right to submit this contribution and grant the project maintainers the rights described therein, including the right to relicense my contributions.
