### PR TITLE
feat: Add OpenAPI 3.0 specification generation

### DIFF
--- a/pkg/openapi/openapi.go
+++ b/pkg/openapi/openapi.go
@@ -1,0 +1,626 @@
+package openapi
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/glyphlang/glyph/pkg/interpreter"
+	"gopkg.in/yaml.v3"
+)
+
+// Spec represents an OpenAPI 3.0 specification.
+type Spec struct {
+	OpenAPI    string                `json:"openapi" yaml:"openapi"`
+	Info       Info                  `json:"info" yaml:"info"`
+	Paths      map[string]*PathItem  `json:"paths" yaml:"paths"`
+	Components *Components           `json:"components,omitempty" yaml:"components,omitempty"`
+	Security   []SecurityRequirement `json:"security,omitempty" yaml:"security,omitempty"`
+}
+
+// Info contains API metadata.
+type Info struct {
+	Title       string `json:"title" yaml:"title"`
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
+	Version     string `json:"version" yaml:"version"`
+}
+
+// PathItem represents operations on a single path.
+type PathItem struct {
+	Get    *Operation `json:"get,omitempty" yaml:"get,omitempty"`
+	Post   *Operation `json:"post,omitempty" yaml:"post,omitempty"`
+	Put    *Operation `json:"put,omitempty" yaml:"put,omitempty"`
+	Delete *Operation `json:"delete,omitempty" yaml:"delete,omitempty"`
+	Patch  *Operation `json:"patch,omitempty" yaml:"patch,omitempty"`
+}
+
+// Operation represents a single API operation.
+type Operation struct {
+	Summary     string                `json:"summary,omitempty" yaml:"summary,omitempty"`
+	OperationID string                `json:"operationId,omitempty" yaml:"operationId,omitempty"`
+	Parameters  []Parameter           `json:"parameters,omitempty" yaml:"parameters,omitempty"`
+	RequestBody *RequestBody          `json:"requestBody,omitempty" yaml:"requestBody,omitempty"`
+	Responses   map[string]*Response  `json:"responses" yaml:"responses"`
+	Security    []SecurityRequirement `json:"security,omitempty" yaml:"security,omitempty"`
+	Tags        []string              `json:"tags,omitempty" yaml:"tags,omitempty"`
+}
+
+// Parameter represents a request parameter (path, query, header).
+type Parameter struct {
+	Name        string  `json:"name" yaml:"name"`
+	In          string  `json:"in" yaml:"in"`
+	Required    bool    `json:"required" yaml:"required"`
+	Description string  `json:"description,omitempty" yaml:"description,omitempty"`
+	Schema      *Schema `json:"schema" yaml:"schema"`
+}
+
+// RequestBody represents a request body.
+type RequestBody struct {
+	Description string               `json:"description,omitempty" yaml:"description,omitempty"`
+	Required    bool                 `json:"required" yaml:"required"`
+	Content     map[string]MediaType `json:"content" yaml:"content"`
+}
+
+// MediaType represents a media type with its schema.
+type MediaType struct {
+	Schema *Schema `json:"schema" yaml:"schema"`
+}
+
+// Response represents a single response.
+type Response struct {
+	Description string               `json:"description" yaml:"description"`
+	Content     map[string]MediaType `json:"content,omitempty" yaml:"content,omitempty"`
+}
+
+// Schema represents a JSON Schema object.
+type Schema struct {
+	Type       string             `json:"type,omitempty" yaml:"type,omitempty"`
+	Format     string             `json:"format,omitempty" yaml:"format,omitempty"`
+	Properties map[string]*Schema `json:"properties,omitempty" yaml:"properties,omitempty"`
+	Required   []string           `json:"required,omitempty" yaml:"required,omitempty"`
+	Items      *Schema            `json:"items,omitempty" yaml:"items,omitempty"`
+	Ref        string             `json:"$ref,omitempty" yaml:"$ref,omitempty"`
+	Nullable   bool               `json:"nullable,omitempty" yaml:"nullable,omitempty"`
+	OneOf      []*Schema          `json:"oneOf,omitempty" yaml:"oneOf,omitempty"`
+}
+
+// Components holds reusable schema definitions.
+type Components struct {
+	Schemas         map[string]*Schema         `json:"schemas,omitempty" yaml:"schemas,omitempty"`
+	SecuritySchemes map[string]*SecurityScheme `json:"securitySchemes,omitempty" yaml:"securitySchemes,omitempty"`
+}
+
+// SecurityScheme describes an auth mechanism.
+type SecurityScheme struct {
+	Type         string `json:"type" yaml:"type"`
+	Scheme       string `json:"scheme,omitempty" yaml:"scheme,omitempty"`
+	BearerFormat string `json:"bearerFormat,omitempty" yaml:"bearerFormat,omitempty"`
+	In           string `json:"in,omitempty" yaml:"in,omitempty"`
+	Name         string `json:"name,omitempty" yaml:"name,omitempty"`
+}
+
+// SecurityRequirement maps security scheme names to scopes.
+type SecurityRequirement map[string][]string
+
+// Generator creates OpenAPI specs from GlyphLang modules.
+type Generator struct {
+	title   string
+	version string
+}
+
+// NewGenerator creates a new OpenAPI generator with the given API title and version.
+func NewGenerator(title, version string) *Generator {
+	return &Generator{
+		title:   title,
+		version: version,
+	}
+}
+
+// Generate produces an OpenAPI 3.0 spec from a parsed GlyphLang module.
+func (g *Generator) Generate(module *interpreter.Module) *Spec {
+	spec := &Spec{
+		OpenAPI: "3.0.3",
+		Info: Info{
+			Title:   g.title,
+			Version: g.version,
+		},
+		Paths: make(map[string]*PathItem),
+		Components: &Components{
+			Schemas:         make(map[string]*Schema),
+			SecuritySchemes: make(map[string]*SecurityScheme),
+		},
+	}
+
+	// First pass: collect all type definitions for schemas
+	// Note: the parser may return either value types (interpreter.TypeDef) or pointer
+	// types (*interpreter.TypeDef), so getTypeDef (defined at line 474) handles both.
+	for _, item := range module.Items {
+		td := getTypeDef(item)
+		if td != nil {
+			spec.Components.Schemas[td.Name] = g.typeDefToSchema(td)
+		}
+	}
+
+	// Second pass: process routes
+	// Note: the parser may return either value types (interpreter.Route) or pointer
+	// types (*interpreter.Route), so getRoute (defined at line 462) handles both.
+	hasAuth := false
+	for _, item := range module.Items {
+		route := getRoute(item)
+		if route == nil {
+			continue
+		}
+		if route.Method == interpreter.WebSocket {
+			continue
+		}
+
+		openAPIPath := glyphPathToOpenAPI(route.Path)
+
+		if spec.Paths[openAPIPath] == nil {
+			spec.Paths[openAPIPath] = &PathItem{}
+		}
+
+		op := g.routeToOperation(route, spec.Components.Schemas)
+
+		switch route.Method {
+		case interpreter.Get:
+			spec.Paths[openAPIPath].Get = op
+		case interpreter.Post:
+			spec.Paths[openAPIPath].Post = op
+		case interpreter.Put:
+			spec.Paths[openAPIPath].Put = op
+		case interpreter.Delete:
+			spec.Paths[openAPIPath].Delete = op
+		case interpreter.Patch:
+			spec.Paths[openAPIPath].Patch = op
+		}
+
+		if route.Auth != nil {
+			hasAuth = true
+			g.addSecurityScheme(spec, route.Auth)
+		}
+	}
+
+	// Clean up empty components
+	if len(spec.Components.Schemas) == 0 && len(spec.Components.SecuritySchemes) == 0 {
+		spec.Components = nil
+	}
+	if !hasAuth {
+		spec.Security = nil
+	}
+
+	return spec
+}
+
+// ToJSON serializes the spec to JSON.
+func (s *Spec) ToJSON() ([]byte, error) {
+	return json.MarshalIndent(s, "", "  ")
+}
+
+// ToYAML serializes the spec to YAML.
+func (s *Spec) ToYAML() ([]byte, error) {
+	return yaml.Marshal(s)
+}
+
+func (g *Generator) routeToOperation(route *interpreter.Route, schemas map[string]*Schema) *Operation {
+	op := &Operation{
+		OperationID: generateOperationID(route),
+		Responses:   make(map[string]*Response),
+	}
+
+	// Extract path parameters
+	pathParams := extractPathParams(route.Path)
+	for _, param := range pathParams {
+		op.Parameters = append(op.Parameters, Parameter{
+			Name:     param,
+			In:       "path",
+			Required: true,
+			Schema:   &Schema{Type: "string"},
+		})
+	}
+
+	// Add query parameters
+	for _, qp := range route.QueryParams {
+		p := Parameter{
+			Name:     qp.Name,
+			In:       "query",
+			Required: qp.Required,
+			Schema:   g.typeToSchema(qp.Type),
+		}
+		if qp.IsArray {
+			p.Schema = &Schema{
+				Type:  "array",
+				Items: p.Schema,
+			}
+		}
+		op.Parameters = append(op.Parameters, p)
+	}
+
+	// Handle request body for POST/PUT/PATCH
+	if route.Method == interpreter.Post || route.Method == interpreter.Put || route.Method == interpreter.Patch {
+		if route.InputType != nil {
+			op.RequestBody = &RequestBody{
+				Required: true,
+				Content: map[string]MediaType{
+					"application/json": {
+						Schema: g.typeToSchema(route.InputType),
+					},
+				},
+			}
+		} else {
+			// Default: accept any JSON body
+			op.RequestBody = &RequestBody{
+				Content: map[string]MediaType{
+					"application/json": {
+						Schema: &Schema{Type: "object"},
+					},
+				},
+			}
+		}
+	}
+
+	// Build response schema
+	if route.ReturnType != nil {
+		responseSchema := g.typeToSchema(route.ReturnType)
+
+		// Check for union type (e.g., User | NotFound)
+		if union, ok := route.ReturnType.(interpreter.UnionType); ok {
+			op.Responses["200"] = &Response{
+				Description: "Successful response",
+				Content: map[string]MediaType{
+					"application/json": {
+						Schema: g.typeToSchema(union.Types[0]),
+					},
+				},
+			}
+			// Add error responses for other union types
+			for i := 1; i < len(union.Types); i++ {
+				statusCode := inferStatusCode(union.Types[i])
+				op.Responses[statusCode] = &Response{
+					Description: inferDescription(union.Types[i]),
+					Content: map[string]MediaType{
+						"application/json": {
+							Schema: g.typeToSchema(union.Types[i]),
+						},
+					},
+				}
+			}
+		} else {
+			op.Responses["200"] = &Response{
+				Description: "Successful response",
+				Content: map[string]MediaType{
+					"application/json": {
+						Schema: responseSchema,
+					},
+				},
+			}
+		}
+	} else {
+		op.Responses["200"] = &Response{
+			Description: "Successful response",
+			Content: map[string]MediaType{
+				"application/json": {
+					Schema: &Schema{Type: "object"},
+				},
+			},
+		}
+	}
+
+	// Add auth security requirement
+	if route.Auth != nil {
+		schemeName := authTypeToSchemeName(route.Auth.AuthType)
+		op.Security = []SecurityRequirement{
+			{schemeName: {}},
+		}
+	}
+
+	// Derive a tag from the path
+	tag := deriveTag(route.Path)
+	if tag != "" {
+		op.Tags = []string{tag}
+	}
+
+	return op
+}
+
+func (g *Generator) typeDefToSchema(td *interpreter.TypeDef) *Schema {
+	schema := &Schema{
+		Type:       "object",
+		Properties: make(map[string]*Schema),
+	}
+
+	var required []string
+	for _, field := range td.Fields {
+		fieldSchema := g.typeToSchema(field.TypeAnnotation)
+
+		if field.Required {
+			required = append(required, field.Name)
+		}
+
+		schema.Properties[field.Name] = fieldSchema
+	}
+
+	if len(required) > 0 {
+		sort.Strings(required)
+		schema.Required = required
+	}
+
+	return schema
+}
+
+func (g *Generator) typeToSchema(t interpreter.Type) *Schema {
+	if t == nil {
+		return &Schema{Type: "object"}
+	}
+
+	switch typ := t.(type) {
+	case interpreter.IntType:
+		return &Schema{Type: "integer", Format: "int64"}
+	case interpreter.FloatType:
+		return &Schema{Type: "number", Format: "double"}
+	case interpreter.StringType:
+		return &Schema{Type: "string"}
+	case interpreter.BoolType:
+		return &Schema{Type: "boolean"}
+	case interpreter.ArrayType:
+		return &Schema{
+			Type:  "array",
+			Items: g.typeToSchema(typ.ElementType),
+		}
+	case interpreter.OptionalType:
+		inner := g.typeToSchema(typ.InnerType)
+		inner.Nullable = true
+		return inner
+	case interpreter.NamedType:
+		return g.namedTypeToSchema(typ.Name)
+	case interpreter.UnionType:
+		var schemas []*Schema
+		for _, ut := range typ.Types {
+			schemas = append(schemas, g.typeToSchema(ut))
+		}
+		return &Schema{OneOf: schemas}
+	case interpreter.GenericType:
+		return g.genericTypeToSchema(typ)
+	case interpreter.DatabaseType:
+		return &Schema{Type: "object"}
+	default:
+		return &Schema{Type: "object"}
+	}
+}
+
+func (g *Generator) namedTypeToSchema(name string) *Schema {
+	switch strings.ToLower(name) {
+	case "timestamp", "datetime":
+		return &Schema{Type: "string", Format: "date-time"}
+	case "date":
+		return &Schema{Type: "string", Format: "date"}
+	case "email":
+		return &Schema{Type: "string", Format: "email"}
+	case "url", "uri":
+		return &Schema{Type: "string", Format: "uri"}
+	case "uuid":
+		return &Schema{Type: "string", Format: "uuid"}
+	case "any":
+		return &Schema{} // no type constraint
+	default:
+		return &Schema{Ref: "#/components/schemas/" + name}
+	}
+}
+
+func (g *Generator) genericTypeToSchema(gt interpreter.GenericType) *Schema {
+	baseName := ""
+	if named, ok := gt.BaseType.(interpreter.NamedType); ok {
+		baseName = named.Name
+	}
+
+	switch strings.ToLower(baseName) {
+	case "list", "array":
+		if len(gt.TypeArgs) > 0 {
+			return &Schema{
+				Type:  "array",
+				Items: g.typeToSchema(gt.TypeArgs[0]),
+			}
+		}
+		return &Schema{Type: "array", Items: &Schema{Type: "object"}}
+	case "map":
+		return &Schema{Type: "object"}
+	default:
+		// Generic named type - just reference it
+		return &Schema{Ref: "#/components/schemas/" + baseName}
+	}
+}
+
+func (g *Generator) addSecurityScheme(spec *Spec, auth *interpreter.AuthConfig) {
+	schemeName := authTypeToSchemeName(auth.AuthType)
+	if _, exists := spec.Components.SecuritySchemes[schemeName]; exists {
+		return
+	}
+
+	switch strings.ToLower(auth.AuthType) {
+	case "jwt", "bearer":
+		spec.Components.SecuritySchemes[schemeName] = &SecurityScheme{
+			Type:         "http",
+			Scheme:       "bearer",
+			BearerFormat: "JWT",
+		}
+	case "basic":
+		spec.Components.SecuritySchemes[schemeName] = &SecurityScheme{
+			Type:   "http",
+			Scheme: "basic",
+		}
+	case "api-key", "apikey":
+		spec.Components.SecuritySchemes[schemeName] = &SecurityScheme{
+			Type: "apiKey",
+			In:   "header",
+			Name: "X-API-Key",
+		}
+	default:
+		spec.Components.SecuritySchemes[schemeName] = &SecurityScheme{
+			Type:   "http",
+			Scheme: auth.AuthType,
+		}
+	}
+}
+
+// getRoute extracts a *Route from an Item, handling both value and pointer types.
+func getRoute(item interpreter.Item) *interpreter.Route {
+	switch v := item.(type) {
+	case interpreter.Route:
+		return &v
+	case *interpreter.Route:
+		return v
+	default:
+		return nil
+	}
+}
+
+// getTypeDef extracts a *TypeDef from an Item, handling both value and pointer types.
+func getTypeDef(item interpreter.Item) *interpreter.TypeDef {
+	switch v := item.(type) {
+	case interpreter.TypeDef:
+		return &v
+	case *interpreter.TypeDef:
+		return v
+	default:
+		return nil
+	}
+}
+
+// glyphPathToOpenAPI converts GlyphLang path params (:id) to OpenAPI format ({id}).
+func glyphPathToOpenAPI(path string) string {
+	parts := strings.Split(path, "/")
+	for i, part := range parts {
+		if strings.HasPrefix(part, ":") {
+			parts[i] = "{" + part[1:] + "}"
+		}
+	}
+	return strings.Join(parts, "/")
+}
+
+// extractPathParams returns the parameter names from a GlyphLang route path.
+func extractPathParams(path string) []string {
+	var params []string
+	for _, part := range strings.Split(path, "/") {
+		if strings.HasPrefix(part, ":") {
+			params = append(params, part[1:])
+		}
+	}
+	return params
+}
+
+func generateOperationID(route *interpreter.Route) string {
+	method := strings.ToLower(route.Method.String())
+	parts := strings.Split(route.Path, "/")
+
+	var segments []string
+	for _, part := range parts {
+		if part == "" {
+			continue
+		}
+		if strings.HasPrefix(part, ":") {
+			segments = append(segments, "by"+capitalize(part[1:]))
+		} else {
+			segments = append(segments, part)
+		}
+	}
+
+	if len(segments) == 0 {
+		return method + "Root"
+	}
+	return method + capitalize(strings.Join(segments, "_"))
+}
+
+func capitalize(s string) string {
+	if s == "" {
+		return s
+	}
+	return strings.ToUpper(s[:1]) + s[1:]
+}
+
+func authTypeToSchemeName(authType string) string {
+	switch strings.ToLower(authType) {
+	case "jwt", "bearer":
+		return "bearerAuth"
+	case "basic":
+		return "basicAuth"
+	case "api-key", "apikey":
+		return "apiKeyAuth"
+	default:
+		return authType + "Auth"
+	}
+}
+
+func deriveTag(path string) string {
+	parts := strings.Split(strings.TrimPrefix(path, "/"), "/")
+	// Use the first two non-empty, non-parameter segments
+	for _, part := range parts {
+		if part != "" && !strings.HasPrefix(part, ":") && part != "api" {
+			return part
+		}
+	}
+	return ""
+}
+
+func inferStatusCode(t interpreter.Type) string {
+	if named, ok := t.(interpreter.NamedType); ok {
+		lower := strings.ToLower(named.Name)
+		switch {
+		case strings.Contains(lower, "notfound"):
+			return "404"
+		case strings.Contains(lower, "unauthorized"):
+			return "401"
+		case strings.Contains(lower, "forbidden"):
+			return "403"
+		case strings.Contains(lower, "badrequest") || strings.Contains(lower, "validation"):
+			return "400"
+		case strings.Contains(lower, "conflict"):
+			return "409"
+		case strings.Contains(lower, "error"):
+			return "500"
+		}
+	}
+	return "default"
+}
+
+func inferDescription(t interpreter.Type) string {
+	if named, ok := t.(interpreter.NamedType); ok {
+		lower := strings.ToLower(named.Name)
+		switch {
+		case strings.Contains(lower, "notfound"):
+			return "Not Found"
+		case strings.Contains(lower, "unauthorized"):
+			return "Unauthorized"
+		case strings.Contains(lower, "forbidden"):
+			return "Forbidden"
+		case strings.Contains(lower, "badrequest"):
+			return "Bad Request"
+		case strings.Contains(lower, "validation"):
+			return "Validation Error"
+		case strings.Contains(lower, "conflict"):
+			return "Conflict"
+		case strings.Contains(lower, "error"):
+			return "Error"
+		}
+		return named.Name
+	}
+	return "Response"
+}
+
+// GenerateFromModule is a convenience function to generate an OpenAPI spec from a module.
+func GenerateFromModule(module *interpreter.Module, title, version string) *Spec {
+	gen := NewGenerator(title, version)
+	return gen.Generate(module)
+}
+
+// FormatSpec serializes a spec in the given format ("json" or "yaml").
+func FormatSpec(spec *Spec, format string) ([]byte, error) {
+	switch strings.ToLower(format) {
+	case "json":
+		return spec.ToJSON()
+	case "yaml", "yml":
+		return spec.ToYAML()
+	default:
+		return nil, fmt.Errorf("unsupported format: %s (use json or yaml)", format)
+	}
+}

--- a/pkg/openapi/openapi_test.go
+++ b/pkg/openapi/openapi_test.go
@@ -1,0 +1,684 @@
+package openapi
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/glyphlang/glyph/pkg/interpreter"
+)
+
+func TestGenerator_EmptyModule(t *testing.T) {
+	gen := NewGenerator("Test API", "1.0.0")
+	module := &interpreter.Module{Items: []interpreter.Item{}}
+	spec := gen.Generate(module)
+
+	if spec.OpenAPI != "3.0.3" {
+		t.Errorf("expected OpenAPI 3.0.3, got %s", spec.OpenAPI)
+	}
+	if spec.Info.Title != "Test API" {
+		t.Errorf("expected title Test API, got %s", spec.Info.Title)
+	}
+	if spec.Info.Version != "1.0.0" {
+		t.Errorf("expected version 1.0.0, got %s", spec.Info.Version)
+	}
+	if len(spec.Paths) != 0 {
+		t.Errorf("expected 0 paths, got %d", len(spec.Paths))
+	}
+}
+
+func TestGenerator_SimpleGetRoute(t *testing.T) {
+	gen := NewGenerator("Test API", "1.0.0")
+	module := &interpreter.Module{
+		Items: []interpreter.Item{
+			interpreter.Route{
+				Path:   "/api/health",
+				Method: interpreter.Get,
+				Body:   []interpreter.Statement{},
+			},
+		},
+	}
+
+	spec := gen.Generate(module)
+
+	path, ok := spec.Paths["/api/health"]
+	if !ok {
+		t.Fatal("expected /api/health path")
+	}
+	if path.Get == nil {
+		t.Fatal("expected GET operation")
+	}
+	if path.Post != nil || path.Put != nil || path.Delete != nil {
+		t.Error("expected only GET operation to be set")
+	}
+	if _, ok := path.Get.Responses["200"]; !ok {
+		t.Error("expected 200 response")
+	}
+}
+
+func TestGenerator_AllHTTPMethods(t *testing.T) {
+	gen := NewGenerator("Test API", "1.0.0")
+	module := &interpreter.Module{
+		Items: []interpreter.Item{
+			interpreter.Route{Path: "/api/users", Method: interpreter.Get},
+			interpreter.Route{Path: "/api/users", Method: interpreter.Post},
+			interpreter.Route{Path: "/api/users/:id", Method: interpreter.Put},
+			interpreter.Route{Path: "/api/users/:id", Method: interpreter.Delete},
+			interpreter.Route{Path: "/api/users/:id", Method: interpreter.Patch},
+		},
+	}
+
+	spec := gen.Generate(module)
+
+	usersPath := spec.Paths["/api/users"]
+	if usersPath == nil {
+		t.Fatal("expected /api/users path")
+	}
+	if usersPath.Get == nil {
+		t.Error("expected GET on /api/users")
+	}
+	if usersPath.Post == nil {
+		t.Error("expected POST on /api/users")
+	}
+
+	usersIdPath := spec.Paths["/api/users/{id}"]
+	if usersIdPath == nil {
+		t.Fatal("expected /api/users/{id} path")
+	}
+	if usersIdPath.Put == nil {
+		t.Error("expected PUT on /api/users/{id}")
+	}
+	if usersIdPath.Delete == nil {
+		t.Error("expected DELETE on /api/users/{id}")
+	}
+	if usersIdPath.Patch == nil {
+		t.Error("expected PATCH on /api/users/{id}")
+	}
+}
+
+func TestGenerator_PathParameters(t *testing.T) {
+	gen := NewGenerator("Test API", "1.0.0")
+	module := &interpreter.Module{
+		Items: []interpreter.Item{
+			interpreter.Route{
+				Path:   "/api/users/:userId/posts/:postId",
+				Method: interpreter.Get,
+			},
+		},
+	}
+
+	spec := gen.Generate(module)
+
+	path := spec.Paths["/api/users/{userId}/posts/{postId}"]
+	if path == nil {
+		t.Fatal("expected path with OpenAPI-style parameters")
+	}
+
+	op := path.Get
+	if len(op.Parameters) != 2 {
+		t.Fatalf("expected 2 path parameters, got %d", len(op.Parameters))
+	}
+
+	if op.Parameters[0].Name != "userId" || op.Parameters[0].In != "path" || !op.Parameters[0].Required {
+		t.Errorf("unexpected first param: %+v", op.Parameters[0])
+	}
+	if op.Parameters[1].Name != "postId" || op.Parameters[1].In != "path" || !op.Parameters[1].Required {
+		t.Errorf("unexpected second param: %+v", op.Parameters[1])
+	}
+}
+
+func TestGenerator_QueryParameters(t *testing.T) {
+	gen := NewGenerator("Test API", "1.0.0")
+	module := &interpreter.Module{
+		Items: []interpreter.Item{
+			interpreter.Route{
+				Path:   "/api/users",
+				Method: interpreter.Get,
+				QueryParams: []interpreter.QueryParamDecl{
+					{Name: "page", Type: interpreter.IntType{}, Required: false},
+					{Name: "q", Type: interpreter.StringType{}, Required: true},
+					{Name: "tags", Type: interpreter.StringType{}, Required: false, IsArray: true},
+				},
+			},
+		},
+	}
+
+	spec := gen.Generate(module)
+	op := spec.Paths["/api/users"].Get
+
+	if len(op.Parameters) != 3 {
+		t.Fatalf("expected 3 query params, got %d", len(op.Parameters))
+	}
+
+	pageParam := op.Parameters[0]
+	if pageParam.Name != "page" || pageParam.In != "query" || pageParam.Required {
+		t.Errorf("unexpected page param: %+v", pageParam)
+	}
+	if pageParam.Schema.Type != "integer" {
+		t.Errorf("expected integer type for page, got %s", pageParam.Schema.Type)
+	}
+
+	qParam := op.Parameters[1]
+	if !qParam.Required {
+		t.Error("expected q to be required")
+	}
+
+	tagsParam := op.Parameters[2]
+	if tagsParam.Schema.Type != "array" {
+		t.Errorf("expected array type for tags, got %s", tagsParam.Schema.Type)
+	}
+}
+
+func TestGenerator_TypeDefinitions(t *testing.T) {
+	gen := NewGenerator("Test API", "1.0.0")
+	module := &interpreter.Module{
+		Items: []interpreter.Item{
+			interpreter.TypeDef{
+				Name: "User",
+				Fields: []interpreter.Field{
+					{Name: "id", TypeAnnotation: interpreter.IntType{}, Required: true},
+					{Name: "name", TypeAnnotation: interpreter.StringType{}, Required: true},
+					{Name: "email", TypeAnnotation: interpreter.OptionalType{InnerType: interpreter.StringType{}}, Required: false},
+					{Name: "roles", TypeAnnotation: interpreter.ArrayType{ElementType: interpreter.StringType{}}},
+					{Name: "score", TypeAnnotation: interpreter.FloatType{}, Required: true},
+					{Name: "active", TypeAnnotation: interpreter.BoolType{}, Required: true},
+				},
+			},
+		},
+	}
+
+	spec := gen.Generate(module)
+
+	userSchema, ok := spec.Components.Schemas["User"]
+	if !ok {
+		t.Fatal("expected User schema in components")
+	}
+
+	if userSchema.Type != "object" {
+		t.Errorf("expected object type, got %s", userSchema.Type)
+	}
+
+	// Check required fields
+	expectedRequired := []string{"active", "id", "name", "score"}
+	if len(userSchema.Required) != len(expectedRequired) {
+		t.Fatalf("expected %d required fields, got %d: %v", len(expectedRequired), len(userSchema.Required), userSchema.Required)
+	}
+	for i, req := range userSchema.Required {
+		if req != expectedRequired[i] {
+			t.Errorf("expected required[%d] = %s, got %s", i, expectedRequired[i], req)
+		}
+	}
+
+	// Check individual fields
+	if userSchema.Properties["id"].Type != "integer" {
+		t.Errorf("expected integer for id, got %s", userSchema.Properties["id"].Type)
+	}
+	if userSchema.Properties["name"].Type != "string" {
+		t.Errorf("expected string for name, got %s", userSchema.Properties["name"].Type)
+	}
+	if !userSchema.Properties["email"].Nullable {
+		t.Error("expected email to be nullable")
+	}
+	if userSchema.Properties["roles"].Type != "array" {
+		t.Errorf("expected array for roles, got %s", userSchema.Properties["roles"].Type)
+	}
+	if userSchema.Properties["score"].Type != "number" {
+		t.Errorf("expected number for score, got %s", userSchema.Properties["score"].Type)
+	}
+	if userSchema.Properties["active"].Type != "boolean" {
+		t.Errorf("expected boolean for active, got %s", userSchema.Properties["active"].Type)
+	}
+}
+
+func TestGenerator_ReturnTypeRef(t *testing.T) {
+	gen := NewGenerator("Test API", "1.0.0")
+	module := &interpreter.Module{
+		Items: []interpreter.Item{
+			interpreter.TypeDef{
+				Name: "User",
+				Fields: []interpreter.Field{
+					{Name: "id", TypeAnnotation: interpreter.IntType{}, Required: true},
+				},
+			},
+			interpreter.Route{
+				Path:       "/api/users/:id",
+				Method:     interpreter.Get,
+				ReturnType: interpreter.NamedType{Name: "User"},
+			},
+		},
+	}
+
+	spec := gen.Generate(module)
+	op := spec.Paths["/api/users/{id}"].Get
+	resp := op.Responses["200"]
+	schema := resp.Content["application/json"].Schema
+
+	if schema.Ref != "#/components/schemas/User" {
+		t.Errorf("expected $ref to User schema, got %s", schema.Ref)
+	}
+}
+
+func TestGenerator_UnionReturnType(t *testing.T) {
+	gen := NewGenerator("Test API", "1.0.0")
+	module := &interpreter.Module{
+		Items: []interpreter.Item{
+			interpreter.Route{
+				Path:   "/api/users/:id",
+				Method: interpreter.Get,
+				ReturnType: interpreter.UnionType{
+					Types: []interpreter.Type{
+						interpreter.NamedType{Name: "User"},
+						interpreter.NamedType{Name: "NotFound"},
+					},
+				},
+			},
+		},
+	}
+
+	spec := gen.Generate(module)
+	op := spec.Paths["/api/users/{id}"].Get
+
+	if _, ok := op.Responses["200"]; !ok {
+		t.Error("expected 200 response")
+	}
+	if _, ok := op.Responses["404"]; !ok {
+		t.Error("expected 404 response for NotFound union member")
+	}
+}
+
+func TestGenerator_AuthJWT(t *testing.T) {
+	gen := NewGenerator("Test API", "1.0.0")
+	module := &interpreter.Module{
+		Items: []interpreter.Item{
+			interpreter.Route{
+				Path:   "/api/me",
+				Method: interpreter.Get,
+				Auth:   &interpreter.AuthConfig{AuthType: "jwt", Required: true},
+			},
+		},
+	}
+
+	spec := gen.Generate(module)
+
+	// Check security scheme
+	scheme, ok := spec.Components.SecuritySchemes["bearerAuth"]
+	if !ok {
+		t.Fatal("expected bearerAuth security scheme")
+	}
+	if scheme.Type != "http" || scheme.Scheme != "bearer" || scheme.BearerFormat != "JWT" {
+		t.Errorf("unexpected JWT scheme: %+v", scheme)
+	}
+
+	// Check operation security
+	op := spec.Paths["/api/me"].Get
+	if len(op.Security) == 0 {
+		t.Fatal("expected security on operation")
+	}
+	if _, ok := op.Security[0]["bearerAuth"]; !ok {
+		t.Error("expected bearerAuth in operation security")
+	}
+}
+
+func TestGenerator_RequestBody(t *testing.T) {
+	gen := NewGenerator("Test API", "1.0.0")
+	module := &interpreter.Module{
+		Items: []interpreter.Item{
+			interpreter.TypeDef{
+				Name: "CreateUserRequest",
+				Fields: []interpreter.Field{
+					{Name: "name", TypeAnnotation: interpreter.StringType{}, Required: true},
+					{Name: "email", TypeAnnotation: interpreter.StringType{}, Required: true},
+				},
+			},
+			interpreter.Route{
+				Path:      "/api/users",
+				Method:    interpreter.Post,
+				InputType: interpreter.NamedType{Name: "CreateUserRequest"},
+			},
+		},
+	}
+
+	spec := gen.Generate(module)
+	op := spec.Paths["/api/users"].Post
+
+	if op.RequestBody == nil {
+		t.Fatal("expected request body for POST")
+	}
+	if !op.RequestBody.Required {
+		t.Error("expected required request body")
+	}
+
+	schema := op.RequestBody.Content["application/json"].Schema
+	if schema.Ref != "#/components/schemas/CreateUserRequest" {
+		t.Errorf("expected ref to CreateUserRequest, got %s", schema.Ref)
+	}
+}
+
+func TestGenerator_PostWithoutInputType(t *testing.T) {
+	gen := NewGenerator("Test API", "1.0.0")
+	module := &interpreter.Module{
+		Items: []interpreter.Item{
+			interpreter.Route{
+				Path:   "/api/action",
+				Method: interpreter.Post,
+			},
+		},
+	}
+
+	spec := gen.Generate(module)
+	op := spec.Paths["/api/action"].Post
+
+	if op.RequestBody == nil {
+		t.Fatal("expected default request body for POST")
+	}
+	schema := op.RequestBody.Content["application/json"].Schema
+	if schema.Type != "object" {
+		t.Errorf("expected default object schema, got %s", schema.Type)
+	}
+}
+
+func TestGenerator_NamedTypeTimestamp(t *testing.T) {
+	gen := NewGenerator("Test API", "1.0.0")
+	module := &interpreter.Module{
+		Items: []interpreter.Item{
+			interpreter.TypeDef{
+				Name: "Event",
+				Fields: []interpreter.Field{
+					{Name: "created_at", TypeAnnotation: interpreter.NamedType{Name: "timestamp"}, Required: true},
+				},
+			},
+		},
+	}
+
+	spec := gen.Generate(module)
+	schema := spec.Components.Schemas["Event"]
+	prop := schema.Properties["created_at"]
+
+	if prop.Type != "string" || prop.Format != "date-time" {
+		t.Errorf("expected string/date-time for timestamp, got %s/%s", prop.Type, prop.Format)
+	}
+}
+
+func TestGenerator_GenericListType(t *testing.T) {
+	gen := NewGenerator("Test API", "1.0.0")
+	module := &interpreter.Module{
+		Items: []interpreter.Item{
+			interpreter.TypeDef{
+				Name: "UserList",
+				Fields: []interpreter.Field{
+					{
+						Name: "users",
+						TypeAnnotation: interpreter.GenericType{
+							BaseType: interpreter.NamedType{Name: "List"},
+							TypeArgs: []interpreter.Type{interpreter.NamedType{Name: "User"}},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	spec := gen.Generate(module)
+	schema := spec.Components.Schemas["UserList"]
+	prop := schema.Properties["users"]
+
+	if prop.Type != "array" {
+		t.Errorf("expected array for List[User], got %s", prop.Type)
+	}
+	if prop.Items == nil || prop.Items.Ref != "#/components/schemas/User" {
+		t.Error("expected items to ref User schema")
+	}
+}
+
+func TestGenerator_WebSocketSkipped(t *testing.T) {
+	gen := NewGenerator("Test API", "1.0.0")
+	module := &interpreter.Module{
+		Items: []interpreter.Item{
+			interpreter.Route{
+				Path:   "/ws/chat",
+				Method: interpreter.WebSocket,
+			},
+			interpreter.Route{
+				Path:   "/api/health",
+				Method: interpreter.Get,
+			},
+		},
+	}
+
+	spec := gen.Generate(module)
+
+	if _, ok := spec.Paths["/ws/chat"]; ok {
+		t.Error("WebSocket routes should be skipped")
+	}
+	if _, ok := spec.Paths["/api/health"]; !ok {
+		t.Error("HTTP routes should be included")
+	}
+}
+
+func TestGenerator_OperationID(t *testing.T) {
+	tests := []struct {
+		method   interpreter.HttpMethod
+		path     string
+		expected string
+	}{
+		{interpreter.Get, "/api/users", "getApi_users"},
+		{interpreter.Post, "/api/users", "postApi_users"},
+		{interpreter.Get, "/api/users/:id", "getApi_users_byId"},
+		{interpreter.Delete, "/api/users/:id/posts/:postId", "deleteApi_users_byId_posts_byPostId"},
+	}
+
+	for _, tt := range tests {
+		route := &interpreter.Route{Path: tt.path, Method: tt.method}
+		got := generateOperationID(route)
+		if got != tt.expected {
+			t.Errorf("operationID for %s %s: expected %s, got %s", tt.method, tt.path, tt.expected, got)
+		}
+	}
+}
+
+func TestGenerator_Tags(t *testing.T) {
+	gen := NewGenerator("Test API", "1.0.0")
+	module := &interpreter.Module{
+		Items: []interpreter.Item{
+			interpreter.Route{Path: "/api/users", Method: interpreter.Get},
+			interpreter.Route{Path: "/api/todos", Method: interpreter.Get},
+		},
+	}
+
+	spec := gen.Generate(module)
+
+	usersOp := spec.Paths["/api/users"].Get
+	if len(usersOp.Tags) == 0 || usersOp.Tags[0] != "users" {
+		t.Errorf("expected users tag, got %v", usersOp.Tags)
+	}
+
+	todosOp := spec.Paths["/api/todos"].Get
+	if len(todosOp.Tags) == 0 || todosOp.Tags[0] != "todos" {
+		t.Errorf("expected todos tag, got %v", todosOp.Tags)
+	}
+}
+
+func TestGlyphPathToOpenAPI(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"/api/users", "/api/users"},
+		{"/api/users/:id", "/api/users/{id}"},
+		{"/api/users/:userId/posts/:postId", "/api/users/{userId}/posts/{postId}"},
+		{"/", "/"},
+	}
+
+	for _, tt := range tests {
+		got := glyphPathToOpenAPI(tt.input)
+		if got != tt.expected {
+			t.Errorf("glyphPathToOpenAPI(%s): expected %s, got %s", tt.input, tt.expected, got)
+		}
+	}
+}
+
+func TestExtractPathParams(t *testing.T) {
+	tests := []struct {
+		path     string
+		expected []string
+	}{
+		{"/api/users", nil},
+		{"/api/users/:id", []string{"id"}},
+		{"/api/users/:userId/posts/:postId", []string{"userId", "postId"}},
+	}
+
+	for _, tt := range tests {
+		got := extractPathParams(tt.path)
+		if len(got) != len(tt.expected) {
+			t.Errorf("extractPathParams(%s): expected %v, got %v", tt.path, tt.expected, got)
+			continue
+		}
+		for i, p := range got {
+			if p != tt.expected[i] {
+				t.Errorf("extractPathParams(%s)[%d]: expected %s, got %s", tt.path, i, tt.expected[i], p)
+			}
+		}
+	}
+}
+
+func TestSpec_ToJSON(t *testing.T) {
+	spec := &Spec{
+		OpenAPI: "3.0.3",
+		Info:    Info{Title: "Test", Version: "1.0.0"},
+		Paths:   map[string]*PathItem{},
+	}
+
+	data, err := spec.ToJSON()
+	if err != nil {
+		t.Fatalf("ToJSON failed: %v", err)
+	}
+
+	var parsed map[string]interface{}
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+
+	if parsed["openapi"] != "3.0.3" {
+		t.Errorf("expected openapi 3.0.3 in JSON output")
+	}
+}
+
+func TestSpec_ToYAML(t *testing.T) {
+	spec := &Spec{
+		OpenAPI: "3.0.3",
+		Info:    Info{Title: "Test", Version: "1.0.0"},
+		Paths:   map[string]*PathItem{},
+	}
+
+	data, err := spec.ToYAML()
+	if err != nil {
+		t.Fatalf("ToYAML failed: %v", err)
+	}
+
+	yamlStr := string(data)
+	if !containsSubstring(yamlStr, "openapi: 3.0.3") {
+		t.Error("expected openapi: 3.0.3 in YAML output")
+	}
+	if !containsSubstring(yamlStr, "title: Test") {
+		t.Error("expected title: Test in YAML output")
+	}
+}
+
+func TestFormatSpec(t *testing.T) {
+	spec := &Spec{
+		OpenAPI: "3.0.3",
+		Info:    Info{Title: "Test", Version: "1.0.0"},
+		Paths:   map[string]*PathItem{},
+	}
+
+	_, err := FormatSpec(spec, "json")
+	if err != nil {
+		t.Errorf("FormatSpec json failed: %v", err)
+	}
+
+	_, err = FormatSpec(spec, "yaml")
+	if err != nil {
+		t.Errorf("FormatSpec yaml failed: %v", err)
+	}
+
+	_, err = FormatSpec(spec, "xml")
+	if err == nil {
+		t.Error("expected error for unsupported format")
+	}
+}
+
+func TestGenerateFromModule(t *testing.T) {
+	module := &interpreter.Module{
+		Items: []interpreter.Item{
+			interpreter.Route{
+				Path:   "/api/test",
+				Method: interpreter.Get,
+			},
+		},
+	}
+
+	spec := GenerateFromModule(module, "My API", "2.0.0")
+	if spec.Info.Title != "My API" {
+		t.Errorf("expected My API, got %s", spec.Info.Title)
+	}
+	if len(spec.Paths) != 1 {
+		t.Errorf("expected 1 path, got %d", len(spec.Paths))
+	}
+}
+
+func TestGenerator_MultipleAuthTypes(t *testing.T) {
+	gen := NewGenerator("Test API", "1.0.0")
+	module := &interpreter.Module{
+		Items: []interpreter.Item{
+			interpreter.Route{
+				Path:   "/api/jwt-route",
+				Method: interpreter.Get,
+				Auth:   &interpreter.AuthConfig{AuthType: "jwt"},
+			},
+			interpreter.Route{
+				Path:   "/api/basic-route",
+				Method: interpreter.Get,
+				Auth:   &interpreter.AuthConfig{AuthType: "basic"},
+			},
+		},
+	}
+
+	spec := gen.Generate(module)
+
+	if _, ok := spec.Components.SecuritySchemes["bearerAuth"]; !ok {
+		t.Error("expected bearerAuth scheme")
+	}
+	if _, ok := spec.Components.SecuritySchemes["basicAuth"]; !ok {
+		t.Error("expected basicAuth scheme")
+	}
+}
+
+func TestGenerator_NoAuthNoSecuritySchemes(t *testing.T) {
+	gen := NewGenerator("Test API", "1.0.0")
+	module := &interpreter.Module{
+		Items: []interpreter.Item{
+			interpreter.Route{
+				Path:   "/api/public",
+				Method: interpreter.Get,
+			},
+		},
+	}
+
+	spec := gen.Generate(module)
+
+	if spec.Components != nil && len(spec.Components.SecuritySchemes) > 0 {
+		t.Error("expected no security schemes for routes without auth")
+	}
+}
+
+func containsSubstring(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsHelper(s, substr))
+}
+
+func containsHelper(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary
- Add `glyph openapi` CLI command to auto-generate OpenAPI 3.0 specs from GlyphLang source
- Add `pkg/openapi` package with full spec generation from parsed AST
- Closes #30

## Changes
- **`pkg/openapi/openapi.go`**: OpenAPI 3.0 generator with route-to-path mapping, type-to-schema conversion, security scheme extraction, path/query parameter handling, union type support, and JSON/YAML output
- **`pkg/openapi/openapi_test.go`**: 24 tests covering all generation features
- **`cmd/glyph/main.go`**: Register `openapi` subcommand with `--output`, `--format`, `--title`, and `--api-version` flags

## Test Plan
- [x] `go build ./...` — builds without errors
- [x] `go test -race ./pkg/openapi/...` — 24 tests pass
- [x] `go test -race ./...` — full suite passes
- [x] `go vet ./...` — no issues
- [x] Manual test: `glyph openapi examples/todo-api/main.glyph` generates valid spec
- [x] Manual test: `glyph openapi examples/auth-demo/main.glyph --format json` includes security schemes

🤖 Generated with [Claude Code](https://claude.com/claude-code)