### PR TITLE
feat: Add MySQL database support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 )
 
 require (
+	filippo.io/edwards25519 v1.1.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
@@ -27,6 +28,7 @@ require (
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
+	github.com/go-sql-driver/mysql v1.9.3 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.3 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+filippo.io/edwards25519 v1.1.0 h1:FNf4tywRC1HmFuKW5xopWpigGjJKiJSV0Cqo0cJWDaA=
+filippo.io/edwards25519 v1.1.0/go.mod h1:BxyFTGdWcka3PhytdK4V28tE5sGfRvvvRV7EaN4VDT4=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=
@@ -18,6 +20,8 @@ github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=
 github.com/go-logr/stdr v1.2.2/go.mod h1:mMo/vtBO5dYbehREoey6XUKy/eSumjCCveDpRre4VKE=
+github.com/go-sql-driver/mysql v1.9.3 h1:U/N249h2WzJ3Ukj8SowVFjdtZKfu9vlLZxjPXV1aweo=
+github.com/go-sql-driver/mysql v1.9.3/go.mod h1:qn46aNg1333BRMNU69Lq93t8du/dwxI64Gl8i5p1WMU=
 github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=

--- a/pkg/database/additional_test.go
+++ b/pkg/database/additional_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // TestNewDatabaseFromString tests creating a database from connection string
@@ -147,15 +148,16 @@ func TestConfig_ConnectionString_DefaultDriver(t *testing.T) {
 	assert.Equal(t, "", result)
 }
 
-// TestNewDatabase_MySQL tests MySQL driver error
+// TestNewDatabase_MySQL tests MySQL driver instantiation
 func TestNewDatabase_MySQL(t *testing.T) {
 	config := &Config{
 		Driver: "mysql",
 	}
 
-	_, err := NewDatabase(config)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "MySQL driver not yet implemented")
+	db, err := NewDatabase(config)
+	require.NoError(t, err)
+	assert.NotNil(t, db)
+	assert.Equal(t, "mysql", db.Driver())
 }
 
 // TestNewDatabase_SQLite tests SQLite driver error
@@ -1743,12 +1745,13 @@ func TestNewDatabase_UnsupportedDriver(t *testing.T) {
 	assert.Contains(t, err.Error(), "unsupported database driver")
 }
 
-// TestNewDatabase_MySQLNotImplemented tests NewDatabase with MySQL driver
-func TestNewDatabase_MySQLNotImplemented(t *testing.T) {
+// TestNewDatabase_MySQLImplemented tests NewDatabase with MySQL driver
+func TestNewDatabase_MySQLImplemented(t *testing.T) {
 	config := &Config{Driver: "mysql"}
-	_, err := NewDatabase(config)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "MySQL driver not yet implemented")
+	db, err := NewDatabase(config)
+	require.NoError(t, err)
+	assert.NotNil(t, db)
+	assert.Equal(t, "mysql", db.Driver())
 }
 
 // TestNewDatabase_SQLiteNotImplemented tests NewDatabase with SQLite driver

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -126,7 +126,8 @@ func NewDatabase(config *Config) (Database, error) {
 	case "postgres", "postgresql":
 		return NewPostgresDB(config), nil
 	case "mysql":
-		return nil, fmt.Errorf("MySQL driver not yet implemented")
+		// NewMySQLDB is defined in mysql.go - mirrors NewPostgresDB pattern
+		return NewMySQLDB(config), nil
 	case "sqlite", "sqlite3":
 		return nil, fmt.Errorf("SQLite driver not yet implemented")
 	default:

--- a/pkg/database/mysql.go
+++ b/pkg/database/mysql.go
@@ -1,0 +1,337 @@
+package database
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+
+	_ "github.com/go-sql-driver/mysql" // MySQL driver
+)
+
+// mysqlIdentifierPattern matches valid MySQL identifiers
+var mysqlIdentifierPattern = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_]*$`)
+
+// SanitizeMySQLIdentifier validates and quotes a MySQL identifier with backticks
+func SanitizeMySQLIdentifier(name string) (string, error) {
+	if name == "" {
+		return "", fmt.Errorf("identifier cannot be empty")
+	}
+	if !mysqlIdentifierPattern.MatchString(name) {
+		return "", ErrInvalidIdentifier
+	}
+	return fmt.Sprintf("`%s`", name), nil
+}
+
+// SanitizeMySQLIdentifiers validates and quotes multiple MySQL identifiers
+func SanitizeMySQLIdentifiers(names []string) ([]string, error) {
+	result := make([]string, len(names))
+	for i, name := range names {
+		sanitized, err := SanitizeMySQLIdentifier(name)
+		if err != nil {
+			return nil, fmt.Errorf("invalid identifier %q: %w", name, err)
+		}
+		result[i] = sanitized
+	}
+	return result, nil
+}
+
+// MySQLDB implements the Database interface for MySQL
+type MySQLDB struct {
+	config *Config
+	db     *sql.DB
+}
+
+// NewMySQLDB creates a new MySQL database instance
+func NewMySQLDB(config *Config) *MySQLDB {
+	return &MySQLDB{
+		config: config,
+	}
+}
+
+// Connect establishes a connection to the MySQL database
+func (m *MySQLDB) Connect(ctx context.Context) error {
+	connStr := m.config.ConnectionString()
+
+	db, err := sql.Open("mysql", connStr)
+	if err != nil {
+		return fmt.Errorf("failed to open database connection: %w", err)
+	}
+
+	// Configure connection pool
+	db.SetMaxOpenConns(m.config.MaxOpenConns)
+	db.SetMaxIdleConns(m.config.MaxIdleConns)
+	db.SetConnMaxLifetime(m.config.ConnMaxLifetime)
+	db.SetConnMaxIdleTime(m.config.ConnMaxIdleTime)
+
+	// Test the connection
+	if err := db.PingContext(ctx); err != nil {
+		db.Close()
+		return fmt.Errorf("failed to ping database: %w", err)
+	}
+
+	m.db = db
+	return nil
+}
+
+// Close closes the database connection
+func (m *MySQLDB) Close() error {
+	if m.db == nil {
+		return nil
+	}
+	return m.db.Close()
+}
+
+// Ping verifies the database connection is alive
+func (m *MySQLDB) Ping(ctx context.Context) error {
+	if m.db == nil {
+		return fmt.Errorf("database not connected")
+	}
+	return m.db.PingContext(ctx)
+}
+
+// Query executes a query that returns rows
+func (m *MySQLDB) Query(ctx context.Context, query string, args ...interface{}) (*sql.Rows, error) {
+	if m.db == nil {
+		return nil, fmt.Errorf("database not connected")
+	}
+	return m.db.QueryContext(ctx, query, args...)
+}
+
+// QueryRow executes a query that returns a single row
+func (m *MySQLDB) QueryRow(ctx context.Context, query string, args ...interface{}) *sql.Row {
+	if m.db == nil {
+		return &sql.Row{}
+	}
+	return m.db.QueryRowContext(ctx, query, args...)
+}
+
+// Exec executes a query that doesn't return rows
+func (m *MySQLDB) Exec(ctx context.Context, query string, args ...interface{}) (sql.Result, error) {
+	if m.db == nil {
+		return nil, fmt.Errorf("database not connected")
+	}
+	return m.db.ExecContext(ctx, query, args...)
+}
+
+// Begin starts a new transaction
+func (m *MySQLDB) Begin(ctx context.Context) (*sql.Tx, error) {
+	if m.db == nil {
+		return nil, fmt.Errorf("database not connected")
+	}
+	return m.db.BeginTx(ctx, nil)
+}
+
+// BeginTx starts a new transaction with options
+func (m *MySQLDB) BeginTx(ctx context.Context, opts *sql.TxOptions) (*sql.Tx, error) {
+	if m.db == nil {
+		return nil, fmt.Errorf("database not connected")
+	}
+	return m.db.BeginTx(ctx, opts)
+}
+
+// Prepare creates a prepared statement
+func (m *MySQLDB) Prepare(ctx context.Context, query string) (*sql.Stmt, error) {
+	if m.db == nil {
+		return nil, fmt.Errorf("database not connected")
+	}
+	return m.db.PrepareContext(ctx, query)
+}
+
+// Stats returns database statistics
+func (m *MySQLDB) Stats() sql.DBStats {
+	if m.db == nil {
+		return sql.DBStats{}
+	}
+	return m.db.Stats()
+}
+
+// Driver returns the driver name
+func (m *MySQLDB) Driver() string {
+	return "mysql"
+}
+
+// Transaction executes a function within a transaction
+func (m *MySQLDB) Transaction(ctx context.Context, fn func(*sql.Tx) error) error {
+	tx, err := m.Begin(ctx)
+	if err != nil {
+		return err
+	}
+
+	defer func() {
+		if r := recover(); r != nil {
+			tx.Rollback()
+			panic(r)
+		}
+	}()
+
+	if err := fn(tx); err != nil {
+		if rbErr := tx.Rollback(); rbErr != nil {
+			return fmt.Errorf("tx error: %v, rollback error: %v", err, rbErr)
+		}
+		return err
+	}
+
+	return tx.Commit()
+}
+
+// BulkInsert performs a bulk insert operation using MySQL syntax
+func (m *MySQLDB) BulkInsert(ctx context.Context, table string, columns []string, values [][]interface{}) error {
+	if len(values) == 0 {
+		return nil
+	}
+
+	sanitizedTable, err := SanitizeMySQLIdentifier(table)
+	if err != nil {
+		return fmt.Errorf("invalid table name: %w", err)
+	}
+
+	sanitizedColumns, err := SanitizeMySQLIdentifiers(columns)
+	if err != nil {
+		return fmt.Errorf("invalid column name: %w", err)
+	}
+
+	// Build the bulk insert query with ? placeholders
+	query := fmt.Sprintf("INSERT INTO %s (%s) VALUES ", sanitizedTable, strings.Join(sanitizedColumns, ", "))
+
+	var args []interface{}
+	for i, row := range values {
+		if i > 0 {
+			query += ", "
+		}
+		query += "("
+		for j := range row {
+			if j > 0 {
+				query += ", "
+			}
+			query += "?"
+			args = append(args, row[j])
+		}
+		query += ")"
+	}
+
+	_, err = m.Exec(ctx, query, args...)
+	return err
+}
+
+// validMySQLColumnTypes contains the allowed MySQL column types
+var validMySQLColumnTypes = map[string]bool{
+	// Numeric types
+	"TINYINT": true, "SMALLINT": true, "MEDIUMINT": true, "INT": true,
+	"INTEGER": true, "BIGINT": true, "FLOAT": true, "DOUBLE": true,
+	"DECIMAL": true, "NUMERIC": true,
+	// Character types
+	"CHAR": true, "VARCHAR": true, "TEXT": true, "TINYTEXT": true,
+	"MEDIUMTEXT": true, "LONGTEXT": true,
+	// Binary types
+	"BINARY": true, "VARBINARY": true, "BLOB": true, "TINYBLOB": true,
+	"MEDIUMBLOB": true, "LONGBLOB": true,
+	// Date/Time types
+	"DATE": true, "TIME": true, "DATETIME": true, "TIMESTAMP": true,
+	"YEAR": true,
+	// Boolean
+	"BOOLEAN": true, "BOOL": true,
+	// JSON
+	"JSON": true,
+	// Enum and Set
+	"ENUM": true, "SET": true,
+}
+
+// mysqlColumnTypePattern matches valid column type definitions
+var mysqlColumnTypePattern = regexp.MustCompile(`^[A-Za-z][A-Za-z0-9_ (),.]*$`)
+
+// sanitizeMySQLColumnType validates a MySQL column type definition
+func sanitizeMySQLColumnType(colType string) (string, error) {
+	if colType == "" {
+		return "", fmt.Errorf("column type cannot be empty")
+	}
+
+	upperType := strings.ToUpper(strings.TrimSpace(colType))
+
+	if !mysqlColumnTypePattern.MatchString(colType) {
+		return "", fmt.Errorf("invalid column type: %s", colType)
+	}
+
+	baseType := strings.Fields(upperType)[0]
+	if idx := strings.Index(baseType, "("); idx != -1 {
+		baseType = baseType[:idx]
+	}
+
+	if !validMySQLColumnTypes[baseType] {
+		return "", fmt.Errorf("unsupported column type: %s", baseType)
+	}
+
+	return colType, nil
+}
+
+// CreateTable creates a table with the given schema
+func (m *MySQLDB) CreateTable(ctx context.Context, table string, schema map[string]string) error {
+	sanitizedTable, err := SanitizeMySQLIdentifier(table)
+	if err != nil {
+		return fmt.Errorf("invalid table name: %w", err)
+	}
+
+	var columnDefs []string
+	for name, colType := range schema {
+		sanitizedName, err := SanitizeMySQLIdentifier(name)
+		if err != nil {
+			return fmt.Errorf("invalid column name %q: %w", name, err)
+		}
+
+		sanitizedType, err := sanitizeMySQLColumnType(colType)
+		if err != nil {
+			return fmt.Errorf("invalid column type for %q: %w", name, err)
+		}
+
+		columnDefs = append(columnDefs, fmt.Sprintf("%s %s", sanitizedName, sanitizedType))
+	}
+
+	query := fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s (%s)", sanitizedTable, strings.Join(columnDefs, ", "))
+	_, err = m.Exec(ctx, query)
+	return err
+}
+
+// DropTable drops a table
+func (m *MySQLDB) DropTable(ctx context.Context, table string) error {
+	sanitizedTable, err := SanitizeMySQLIdentifier(table)
+	if err != nil {
+		return fmt.Errorf("invalid table name: %w", err)
+	}
+
+	query := fmt.Sprintf("DROP TABLE IF EXISTS %s", sanitizedTable)
+	_, err = m.Exec(ctx, query)
+	return err
+}
+
+// TableExists checks if a table exists in MySQL
+func (m *MySQLDB) TableExists(ctx context.Context, table string) (bool, error) {
+	query := `
+		SELECT COUNT(*) FROM information_schema.tables
+		WHERE table_schema = DATABASE()
+		AND table_name = ?
+	`
+	var count int
+	err := m.QueryRow(ctx, query, table).Scan(&count)
+	return count > 0, err
+}
+
+// GetLastInsertID retrieves the last inserted ID (MySQL specific)
+func (m *MySQLDB) GetLastInsertID(ctx context.Context, table string, idColumn string) (int64, error) {
+	if err := ValidateIdentifier(table); err != nil {
+		return 0, fmt.Errorf("invalid table name: %w", err)
+	}
+	if err := ValidateIdentifier(idColumn); err != nil {
+		return 0, fmt.Errorf("invalid column name: %w", err)
+	}
+
+	var id int64
+	err := m.QueryRow(ctx, "SELECT LAST_INSERT_ID()").Scan(&id)
+	return id, err
+}
+
+// WithMySQLTimeout wraps a context with a timeout
+func WithMySQLTimeout(ctx context.Context, timeout time.Duration) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(ctx, timeout)
+}

--- a/pkg/database/mysql_test.go
+++ b/pkg/database/mysql_test.go
@@ -1,0 +1,314 @@
+package database
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewMySQLDB(t *testing.T) {
+	config := &Config{
+		Driver:   "mysql",
+		Host:     "localhost",
+		Port:     3306,
+		Database: "testdb",
+		Username: "user",
+		Password: "pass",
+	}
+
+	db := NewMySQLDB(config)
+	assert.NotNil(t, db)
+	assert.Equal(t, "mysql", db.Driver())
+	assert.Nil(t, db.db)
+}
+
+func TestMySQLDB_DriverName(t *testing.T) {
+	db := NewMySQLDB(&Config{Driver: "mysql"})
+	assert.Equal(t, "mysql", db.Driver())
+}
+
+func TestMySQLDB_CloseNilDB(t *testing.T) {
+	db := NewMySQLDB(&Config{Driver: "mysql"})
+	err := db.Close()
+	assert.NoError(t, err)
+}
+
+func TestMySQLDB_PingNotConnected(t *testing.T) {
+	ctx := context.Background()
+	db := NewMySQLDB(&Config{Driver: "mysql"})
+	err := db.Ping(ctx)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "database not connected")
+}
+
+func TestMySQLDB_QueryNotConnected(t *testing.T) {
+	ctx := context.Background()
+	db := NewMySQLDB(&Config{Driver: "mysql"})
+	_, err := db.Query(ctx, "SELECT 1")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "database not connected")
+}
+
+func TestMySQLDB_ExecNotConnected(t *testing.T) {
+	ctx := context.Background()
+	db := NewMySQLDB(&Config{Driver: "mysql"})
+	_, err := db.Exec(ctx, "SELECT 1")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "database not connected")
+}
+
+func TestMySQLDB_BeginNotConnected(t *testing.T) {
+	ctx := context.Background()
+	db := NewMySQLDB(&Config{Driver: "mysql"})
+	_, err := db.Begin(ctx)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "database not connected")
+}
+
+func TestMySQLDB_BeginTxNotConnected(t *testing.T) {
+	ctx := context.Background()
+	db := NewMySQLDB(&Config{Driver: "mysql"})
+	_, err := db.BeginTx(ctx, nil)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "database not connected")
+}
+
+func TestMySQLDB_PrepareNotConnected(t *testing.T) {
+	ctx := context.Background()
+	db := NewMySQLDB(&Config{Driver: "mysql"})
+	_, err := db.Prepare(ctx, "SELECT 1")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "database not connected")
+}
+
+func TestMySQLDB_StatsNotConnected(t *testing.T) {
+	db := NewMySQLDB(&Config{Driver: "mysql"})
+	stats := db.Stats()
+	assert.Equal(t, 0, stats.OpenConnections)
+}
+
+func TestMySQLDB_QueryRowNotConnected(t *testing.T) {
+	ctx := context.Background()
+	db := NewMySQLDB(&Config{Driver: "mysql"})
+	row := db.QueryRow(ctx, "SELECT 1")
+	assert.NotNil(t, row)
+}
+
+// SanitizeMySQLIdentifier tests
+
+func TestSanitizeMySQLIdentifier(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:  "valid identifier",
+			input: "users",
+			want:  "`users`",
+		},
+		{
+			name:  "identifier with underscore",
+			input: "user_name",
+			want:  "`user_name`",
+		},
+		{
+			name:  "identifier starting with underscore",
+			input: "_id",
+			want:  "`_id`",
+		},
+		{
+			name:    "empty identifier",
+			input:   "",
+			wantErr: true,
+		},
+		{
+			name:    "identifier with spaces",
+			input:   "user name",
+			wantErr: true,
+		},
+		{
+			name:    "identifier with SQL injection",
+			input:   "users; DROP TABLE users",
+			wantErr: true,
+		},
+		{
+			name:    "identifier starting with number",
+			input:   "123users",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := SanitizeMySQLIdentifier(tt.input)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestSanitizeMySQLIdentifiers(t *testing.T) {
+	names := []string{"id", "name", "email"}
+	result, err := SanitizeMySQLIdentifiers(names)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"`id`", "`name`", "`email`"}, result)
+
+	// Test with invalid identifier
+	_, err = SanitizeMySQLIdentifiers([]string{"valid", "invalid name"})
+	assert.Error(t, err)
+}
+
+// sanitizeMySQLColumnType tests (same-package access to unexported function)
+
+func TestSanitizeMySQLColumnType(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		{name: "INT", input: "INT"},
+		{name: "VARCHAR with length", input: "VARCHAR(255)"},
+		{name: "TEXT", input: "TEXT"},
+		{name: "DATETIME", input: "DATETIME"},
+		{name: "BOOLEAN", input: "BOOLEAN"},
+		{name: "JSON", input: "JSON"},
+		{name: "BIGINT", input: "BIGINT"},
+		{name: "DECIMAL with precision", input: "DECIMAL(10, 2)"},
+		{name: "empty", input: "", wantErr: true},
+		{name: "unsupported type", input: "FAKETYPE", wantErr: true},
+		{name: "injection attempt", input: "INT; DROP TABLE", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := sanitizeMySQLColumnType(tt.input)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.input, result)
+		})
+	}
+}
+
+// Factory and connection string tests
+
+func TestNewDatabase_MySQLDriver(t *testing.T) {
+	config := &Config{
+		Driver:   "mysql",
+		Host:     "localhost",
+		Port:     3306,
+		Database: "testdb",
+		Username: "user",
+		Password: "pass",
+	}
+
+	db, err := NewDatabase(config)
+	require.NoError(t, err)
+	assert.NotNil(t, db)
+	assert.Equal(t, "mysql", db.Driver())
+}
+
+func TestMySQLConnectionString(t *testing.T) {
+	config := &Config{
+		Driver:   "mysql",
+		Host:     "localhost",
+		Port:     3306,
+		Database: "testdb",
+		Username: "root",
+		Password: "secret",
+	}
+
+	connStr := config.ConnectionString()
+	assert.Equal(t, "root:secret@tcp(localhost:3306)/testdb", connStr)
+}
+
+func TestParseMySQLConnectionString(t *testing.T) {
+	cfg, err := ParseConnectionString("mysql://user:pass@localhost:3306/mydb")
+	require.NoError(t, err)
+	assert.Equal(t, "mysql", cfg.Driver)
+	assert.Equal(t, "localhost", cfg.Host)
+	assert.Equal(t, 3306, cfg.Port)
+	assert.Equal(t, "mydb", cfg.Database)
+	assert.Equal(t, "user", cfg.Username)
+	assert.Equal(t, "pass", cfg.Password)
+}
+
+func TestParseMySQLConnectionString_DefaultPort(t *testing.T) {
+	cfg, err := ParseConnectionString("mysql://user:pass@localhost/mydb")
+	require.NoError(t, err)
+	assert.Equal(t, 3306, cfg.Port)
+}
+
+// Validation and edge case tests
+
+func TestMySQLDB_BulkInsertEmpty(t *testing.T) {
+	db := NewMySQLDB(&Config{Driver: "mysql"})
+	err := db.BulkInsert(context.Background(), "users", []string{"id", "name"}, [][]interface{}{})
+	assert.NoError(t, err)
+}
+
+func TestMySQLDB_BulkInsertInvalidTable(t *testing.T) {
+	db := NewMySQLDB(&Config{Driver: "mysql"})
+	err := db.BulkInsert(context.Background(), "invalid table", []string{"id"}, [][]interface{}{{1}})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid table name")
+}
+
+func TestMySQLDB_BulkInsertInvalidColumn(t *testing.T) {
+	db := NewMySQLDB(&Config{Driver: "mysql"})
+	err := db.BulkInsert(context.Background(), "users", []string{"invalid col"}, [][]interface{}{{1}})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid column name")
+}
+
+func TestMySQLDB_CreateTableInvalidTable(t *testing.T) {
+	db := NewMySQLDB(&Config{Driver: "mysql"})
+	err := db.CreateTable(context.Background(), "invalid table", map[string]string{"id": "INT"})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid table name")
+}
+
+func TestMySQLDB_CreateTableInvalidColumn(t *testing.T) {
+	db := NewMySQLDB(&Config{Driver: "mysql"})
+	err := db.CreateTable(context.Background(), "users", map[string]string{"invalid col": "INT"})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid column name")
+}
+
+func TestMySQLDB_CreateTableInvalidType(t *testing.T) {
+	db := NewMySQLDB(&Config{Driver: "mysql"})
+	err := db.CreateTable(context.Background(), "users", map[string]string{"id": "FAKETYPE"})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid column type")
+}
+
+func TestMySQLDB_DropTableInvalidTable(t *testing.T) {
+	db := NewMySQLDB(&Config{Driver: "mysql"})
+	err := db.DropTable(context.Background(), "invalid table")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid table name")
+}
+
+func TestMySQLDB_GetLastInsertIDInvalidTable(t *testing.T) {
+	db := NewMySQLDB(&Config{Driver: "mysql"})
+	_, err := db.GetLastInsertID(context.Background(), "invalid table", "id")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid table name")
+}
+
+func TestMySQLDB_GetLastInsertIDInvalidColumn(t *testing.T) {
+	db := NewMySQLDB(&Config{Driver: "mysql"})
+	_, err := db.GetLastInsertID(context.Background(), "users", "invalid col")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid column name")
+}


### PR DESCRIPTION
## Summary
- Implements MySQL database driver following the existing PostgreSQL pattern
- Closes #34

## Changes
- Created `pkg/database/mysql.go` with `MySQLDB` struct implementing the `Database` interface
  - Connection management with pool configuration
  - Query execution with MySQL `?` parameter placeholders
  - Transaction support with rollback on panic
  - Bulk insert with MySQL syntax
  - DDL operations (CreateTable, DropTable, TableExists) with backtick identifier quoting
  - MySQL-specific column type validation
  - SQL injection protection via identifier sanitization
- Updated `pkg/database/database.go` to instantiate `MySQLDB` from the factory
- Added `github.com/go-sql-driver/mysql` driver dependency
- Created `pkg/database/mysql_test.go` with 28 tests covering:
  - Constructor and driver name
  - All operations in disconnected state (error handling)
  - Identifier sanitization (valid, invalid, injection attempts)
  - Column type validation
  - Factory instantiation and connection string generation
  - Bulk insert, DDL, and edge case validation
- Updated existing tests that asserted MySQL was "not yet implemented"

## Test Plan
- `go test -race ./pkg/database/` — all 28 new MySQL tests pass
- `go test -race ./...` — full suite passes (no regressions)
- `go vet ./...` — clean
- `go build ./...` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)