### PR TITLE
fix: Use atomic operations for evalDepth to prevent race condition

### DIFF
--- a/pkg/interpreter/evaldepth_race_test.go
+++ b/pkg/interpreter/evaldepth_race_test.go
@@ -1,0 +1,76 @@
+package interpreter
+
+import (
+	. "github.com/glyphlang/glyph/pkg/ast"
+
+	"sync"
+	"testing"
+)
+
+// TestEvalDepthConcurrentAccess verifies that concurrent expression evaluation
+// does not race on the evalDepth counter. This test should be run with -race.
+func TestEvalDepthConcurrentAccess(t *testing.T) {
+	interp := NewInterpreter()
+	env := NewEnvironment()
+
+	// Simple expression that won't error
+	expr := LiteralExpr{Value: IntLiteral{Value: 42}}
+
+	var wg sync.WaitGroup
+	const goroutines = 50
+	const iterations = 100
+
+	for g := 0; g < goroutines; g++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < iterations; j++ {
+				result, err := interp.EvaluateExpression(expr, env)
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+					return
+				}
+				if result != int64(42) {
+					t.Errorf("expected 42, got %v", result)
+					return
+				}
+			}
+		}()
+	}
+
+	wg.Wait()
+}
+
+// TestEvalDepthConcurrentAsyncExpr verifies that async expressions
+// properly handle concurrent evalDepth access.
+func TestEvalDepthConcurrentAsyncExpr(t *testing.T) {
+	interp := NewInterpreter()
+	env := NewEnvironment()
+
+	// Create multiple async expressions that each evaluate nested expressions
+	var wg sync.WaitGroup
+	const goroutines = 20
+
+	for g := 0; g < goroutines; g++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			// Evaluate a binary expression concurrently
+			expr := BinaryOpExpr{
+				Left:  LiteralExpr{Value: IntLiteral{Value: 10}},
+				Op:    Add,
+				Right: LiteralExpr{Value: IntLiteral{Value: 20}},
+			}
+			result, err := interp.EvaluateExpression(expr, env)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+			if result != int64(30) {
+				t.Errorf("expected 30, got %v", result)
+			}
+		}()
+	}
+
+	wg.Wait()
+}

--- a/pkg/interpreter/evaluator.go
+++ b/pkg/interpreter/evaluator.go
@@ -5,6 +5,7 @@ import (
 
 	"fmt"
 	"strings"
+	"sync/atomic"
 	"unicode"
 )
 
@@ -21,12 +22,12 @@ func capitalizeFirst(s string) string {
 
 // EvaluateExpression evaluates an expression and returns its value
 func (i *Interpreter) EvaluateExpression(expr Expr, env *Environment) (interface{}, error) {
-	i.evalDepth++
-	if i.evalDepth > maxEvalDepth {
-		i.evalDepth--
+	depth := atomic.AddInt64(&i.evalDepth, 1)
+	if depth > maxEvalDepth {
+		atomic.AddInt64(&i.evalDepth, -1)
 		return nil, fmt.Errorf("maximum evaluation depth exceeded (%d levels)", maxEvalDepth)
 	}
-	defer func() { i.evalDepth-- }()
+	defer atomic.AddInt64(&i.evalDepth, -1)
 	switch e := expr.(type) {
 	case LiteralExpr:
 		return i.evaluateLiteral(e.Value)

--- a/pkg/interpreter/interpreter.go
+++ b/pkg/interpreter/interpreter.go
@@ -37,7 +37,7 @@ type Interpreter struct {
 	constants        map[string]struct{}      // Tracks names that are constants (immutable)
 	contracts        map[string]ContractDef   // Contract definitions by name
 	traitDefs        map[string]TraitDef      // Trait definitions by name
-	evalDepth        int                      // Current recursion depth for evaluation
+	evalDepth        int64                    // Current recursion depth for evaluation (atomic)
 }
 
 // NewInterpreter creates a new interpreter instance


### PR DESCRIPTION
## Summary
- Fix race condition on `evalDepth` counter during concurrent async expression evaluation
- Replace direct `int` field access with `atomic.AddInt64` operations
- Closes #119

## Changes
- Changed `evalDepth` field type from `int` to `int64` in `Interpreter` struct
- Added `sync/atomic` import to `evaluator.go`
- Replaced direct increment/decrement with `atomic.AddInt64` calls in `EvaluateExpression`
- Added `evaldepth_race_test.go` with concurrent evaluation tests

## Test Plan
- [x] All existing tests pass with `-race` detector
- [x] New `TestEvalDepthConcurrentAccess` verifies 50 goroutines x 100 iterations with no race
- [x] New `TestEvalDepthConcurrentAsyncExpr` verifies concurrent binary op evaluation
- [x] `go vet ./...` passes
- [x] `gofmt -l .` clean