### PR TITLE
fix: Consistent int/float coercion across all numeric operators

### DIFF
--- a/pkg/interpreter/coercion_test.go
+++ b/pkg/interpreter/coercion_test.go
@@ -43,42 +43,42 @@ func TestCoercion_Sub_IntAndFloat(t *testing.T) {
 	interp := NewInterpreter()
 	env := NewEnvironment()
 
-	// 10 - 3.5 should error (strict type checking for subtraction)
+	// 10 - 3.5 should coerce int to float (consistent with Add)
 	left := LiteralExpr{Value: IntLiteral{Value: 10}}
 	right := LiteralExpr{Value: FloatLiteral{Value: 3.5}}
 	expr := BinaryOpExpr{Left: left, Op: Sub, Right: right}
 
-	_, err := interp.EvaluateExpression(expr, env)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "cannot subtract")
+	result, err := interp.EvaluateExpression(expr, env)
+	require.NoError(t, err)
+	assert.Equal(t, float64(6.5), result)
 }
 
 func TestCoercion_Mul_IntAndFloat(t *testing.T) {
 	interp := NewInterpreter()
 	env := NewEnvironment()
 
-	// 4 * 2.5 should error (strict type checking for multiplication)
+	// 4 * 2.5 should coerce int to float (consistent with Add)
 	left := LiteralExpr{Value: IntLiteral{Value: 4}}
 	right := LiteralExpr{Value: FloatLiteral{Value: 2.5}}
 	expr := BinaryOpExpr{Left: left, Op: Mul, Right: right}
 
-	_, err := interp.EvaluateExpression(expr, env)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "cannot multiply")
+	result, err := interp.EvaluateExpression(expr, env)
+	require.NoError(t, err)
+	assert.Equal(t, float64(10.0), result)
 }
 
 func TestCoercion_Div_IntAndFloat(t *testing.T) {
 	interp := NewInterpreter()
 	env := NewEnvironment()
 
-	// 10 / 2.5 should error (strict type checking for division)
+	// 10 / 2.5 should coerce int to float (consistent with Add)
 	left := LiteralExpr{Value: IntLiteral{Value: 10}}
 	right := LiteralExpr{Value: FloatLiteral{Value: 2.5}}
 	expr := BinaryOpExpr{Left: left, Op: Div, Right: right}
 
-	_, err := interp.EvaluateExpression(expr, env)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "cannot divide")
+	result, err := interp.EvaluateExpression(expr, env)
+	require.NoError(t, err)
+	assert.Equal(t, float64(4.0), result)
 }
 
 // Test numeric coercion in comparison operations
@@ -129,56 +129,56 @@ func TestCoercion_Lt_IntAndFloat(t *testing.T) {
 	interp := NewInterpreter()
 	env := NewEnvironment()
 
-	// 5 < 5.5 should error (strict type checking for comparisons)
+	// 5 < 5.5 should coerce int to float and return true
 	left := LiteralExpr{Value: IntLiteral{Value: 5}}
 	right := LiteralExpr{Value: FloatLiteral{Value: 5.5}}
 	expr := BinaryOpExpr{Left: left, Op: Lt, Right: right}
 
-	_, err := interp.EvaluateExpression(expr, env)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "cannot compare")
+	result, err := interp.EvaluateExpression(expr, env)
+	require.NoError(t, err)
+	assert.Equal(t, true, result)
 }
 
 func TestCoercion_Le_FloatAndInt(t *testing.T) {
 	interp := NewInterpreter()
 	env := NewEnvironment()
 
-	// 5.0 <= 5 should error (strict type checking for comparisons)
+	// 5.0 <= 5 should coerce int to float and return true
 	left := LiteralExpr{Value: FloatLiteral{Value: 5.0}}
 	right := LiteralExpr{Value: IntLiteral{Value: 5}}
 	expr := BinaryOpExpr{Left: left, Op: Le, Right: right}
 
-	_, err := interp.EvaluateExpression(expr, env)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "cannot compare")
+	result, err := interp.EvaluateExpression(expr, env)
+	require.NoError(t, err)
+	assert.Equal(t, true, result)
 }
 
 func TestCoercion_Gt_FloatAndInt(t *testing.T) {
 	interp := NewInterpreter()
 	env := NewEnvironment()
 
-	// 5.5 > 5 should error (strict type checking for comparisons)
+	// 5.5 > 5 should coerce int to float and return true
 	left := LiteralExpr{Value: FloatLiteral{Value: 5.5}}
 	right := LiteralExpr{Value: IntLiteral{Value: 5}}
 	expr := BinaryOpExpr{Left: left, Op: Gt, Right: right}
 
-	_, err := interp.EvaluateExpression(expr, env)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "cannot compare")
+	result, err := interp.EvaluateExpression(expr, env)
+	require.NoError(t, err)
+	assert.Equal(t, true, result)
 }
 
 func TestCoercion_Ge_IntAndFloat(t *testing.T) {
 	interp := NewInterpreter()
 	env := NewEnvironment()
 
-	// 5 >= 4.9 should error (strict type checking for comparisons)
+	// 5 >= 4.9 should coerce int to float and return true
 	left := LiteralExpr{Value: IntLiteral{Value: 5}}
 	right := LiteralExpr{Value: FloatLiteral{Value: 4.9}}
 	expr := BinaryOpExpr{Left: left, Op: Ge, Right: right}
 
-	_, err := interp.EvaluateExpression(expr, env)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "cannot compare")
+	result, err := interp.EvaluateExpression(expr, env)
+	require.NoError(t, err)
+	assert.Equal(t, true, result)
 }
 
 // Test that same-type operations still work
@@ -217,9 +217,9 @@ func TestCoercion_ChainedOperations(t *testing.T) {
 	interp := NewInterpreter()
 	env := NewEnvironment()
 
-	// (5 + 2.5) * 3 should work with Add coercion, but then fail on Mul
-	// First: 5 + 2.5 = 7.5 (float) - Add allows coercion
-	// Then: 7.5 * 3 should error - Mul does not allow type mixing
+	// (5 + 2.5) * 3 should work: both Add and Mul now allow coercion
+	// First: 5 + 2.5 = 7.5 (float)
+	// Then: 7.5 * 3 = 22.5 (int coerced to float)
 	inner := BinaryOpExpr{
 		Left:  LiteralExpr{Value: IntLiteral{Value: 5}},
 		Op:    Add,
@@ -231,23 +231,23 @@ func TestCoercion_ChainedOperations(t *testing.T) {
 		Right: LiteralExpr{Value: IntLiteral{Value: 3}},
 	}
 
-	_, err := interp.EvaluateExpression(expr, env)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "cannot multiply")
+	result, err := interp.EvaluateExpression(expr, env)
+	require.NoError(t, err)
+	assert.Equal(t, float64(22.5), result)
 }
 
 func TestCoercion_DivisionByZero_Float(t *testing.T) {
 	interp := NewInterpreter()
 	env := NewEnvironment()
 
-	// 5 / 0.0 should error due to type mismatch (not division by zero)
+	// 5 / 0.0 should coerce and then error with division by zero
 	left := LiteralExpr{Value: IntLiteral{Value: 5}}
 	right := LiteralExpr{Value: FloatLiteral{Value: 0.0}}
 	expr := BinaryOpExpr{Left: left, Op: Div, Right: right}
 
 	_, err := interp.EvaluateExpression(expr, env)
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "cannot divide")
+	assert.Contains(t, err.Error(), "division by zero")
 }
 
 func TestCoercion_NoCoercionForString(t *testing.T) {

--- a/pkg/interpreter/evaluator.go
+++ b/pkg/interpreter/evaluator.go
@@ -349,13 +349,8 @@ func (i *Interpreter) evaluateAdd(left, right interface{}) (interface{}, error) 
 
 // evaluateSub handles subtraction
 func (i *Interpreter) evaluateSub(left, right interface{}) (interface{}, error) {
-	// Numeric subtraction - do not allow automatic coercion
-	coercedLeft, coercedRight, coerced := CoerceNumeric(left, right)
-
-	// If coercion happened, return error (strict type checking for subtraction)
-	if coerced {
-		return nil, fmt.Errorf("cannot subtract %T and %T", left, right)
-	}
+	// Numeric subtraction with automatic coercion (int->float promotion)
+	coercedLeft, coercedRight, _ := CoerceNumeric(left, right)
 
 	// Integer subtraction
 	if leftInt, ok := coercedLeft.(int64); ok {
@@ -376,13 +371,8 @@ func (i *Interpreter) evaluateSub(left, right interface{}) (interface{}, error) 
 
 // evaluateMul handles multiplication
 func (i *Interpreter) evaluateMul(left, right interface{}) (interface{}, error) {
-	// Numeric multiplication - do not allow automatic coercion
-	coercedLeft, coercedRight, coerced := CoerceNumeric(left, right)
-
-	// If coercion happened, return error (strict type checking for multiplication)
-	if coerced {
-		return nil, fmt.Errorf("cannot multiply %T and %T", left, right)
-	}
+	// Numeric multiplication with automatic coercion (int->float promotion)
+	coercedLeft, coercedRight, _ := CoerceNumeric(left, right)
 
 	// Integer multiplication
 	if leftInt, ok := coercedLeft.(int64); ok {
@@ -403,13 +393,8 @@ func (i *Interpreter) evaluateMul(left, right interface{}) (interface{}, error) 
 
 // evaluateDiv handles division
 func (i *Interpreter) evaluateDiv(left, right interface{}) (interface{}, error) {
-	// Numeric division - do not allow automatic coercion
-	coercedLeft, coercedRight, coerced := CoerceNumeric(left, right)
-
-	// If coercion happened, return error (strict type checking for division)
-	if coerced {
-		return nil, fmt.Errorf("cannot divide %T and %T", left, right)
-	}
+	// Numeric division - allow int/float coercion for consistency with Add/Eq (#122)
+	coercedLeft, coercedRight, _ := CoerceNumeric(left, right)
 
 	// Integer division
 	if leftInt, ok := coercedLeft.(int64); ok {
@@ -462,13 +447,8 @@ func (i *Interpreter) evaluateNe(left, right interface{}) (interface{}, error) {
 
 // evaluateLt handles less than comparison
 func (i *Interpreter) evaluateLt(left, right interface{}) (interface{}, error) {
-	// Numeric comparison - do not allow automatic coercion
-	coercedLeft, coercedRight, coerced := CoerceNumeric(left, right)
-
-	// If coercion happened, return error (strict type checking)
-	if coerced {
-		return nil, fmt.Errorf("cannot compare %T and %T", left, right)
-	}
+	// Numeric comparison - allow int/float coercion for consistency with Add/Eq (#122)
+	coercedLeft, coercedRight, _ := CoerceNumeric(left, right)
 
 	// Integer comparison
 	if leftInt, ok := coercedLeft.(int64); ok {
@@ -489,13 +469,8 @@ func (i *Interpreter) evaluateLt(left, right interface{}) (interface{}, error) {
 
 // evaluateLe handles less than or equal comparison
 func (i *Interpreter) evaluateLe(left, right interface{}) (interface{}, error) {
-	// Numeric comparison - do not allow automatic coercion
-	coercedLeft, coercedRight, coerced := CoerceNumeric(left, right)
-
-	// If coercion happened, return error (strict type checking)
-	if coerced {
-		return nil, fmt.Errorf("cannot compare %T and %T", left, right)
-	}
+	// Numeric comparison - allow int/float coercion for consistency with Add/Eq (#122)
+	coercedLeft, coercedRight, _ := CoerceNumeric(left, right)
 
 	// Integer comparison
 	if leftInt, ok := coercedLeft.(int64); ok {
@@ -516,13 +491,8 @@ func (i *Interpreter) evaluateLe(left, right interface{}) (interface{}, error) {
 
 // evaluateGt handles greater than comparison
 func (i *Interpreter) evaluateGt(left, right interface{}) (interface{}, error) {
-	// Numeric comparison - do not allow automatic coercion
-	coercedLeft, coercedRight, coerced := CoerceNumeric(left, right)
-
-	// If coercion happened, return error (strict type checking)
-	if coerced {
-		return nil, fmt.Errorf("cannot compare %T and %T", left, right)
-	}
+	// Allow int/float coercion for consistency with evaluateAdd, evaluateEq, evaluateLt, evaluateLe (#122)
+	coercedLeft, coercedRight, _ := CoerceNumeric(left, right)
 
 	// Integer comparison
 	if leftInt, ok := coercedLeft.(int64); ok {
@@ -543,13 +513,8 @@ func (i *Interpreter) evaluateGt(left, right interface{}) (interface{}, error) {
 
 // evaluateGe handles greater than or equal comparison
 func (i *Interpreter) evaluateGe(left, right interface{}) (interface{}, error) {
-	// Numeric comparison - do not allow automatic coercion
-	coercedLeft, coercedRight, coerced := CoerceNumeric(left, right)
-
-	// If coercion happened, return error (strict type checking)
-	if coerced {
-		return nil, fmt.Errorf("cannot compare %T and %T", left, right)
-	}
+	// Allow int/float coercion for consistency with evaluateAdd, evaluateEq, evaluateLt, evaluateLe (#122)
+	coercedLeft, coercedRight, _ := CoerceNumeric(left, right)
 
 	// Integer comparison
 	if leftInt, ok := coercedLeft.(int64); ok {

--- a/pkg/interpreter/interpreter_test.go
+++ b/pkg/interpreter/interpreter_test.go
@@ -1510,15 +1510,16 @@ func TestEvaluateSub_TypeMismatch(t *testing.T) {
 	interp := NewInterpreter()
 	env := NewEnvironment()
 
+	// int - float now coerces int to float (consistent with Add)
 	expr := BinaryOpExpr{
 		Left:  LiteralExpr{Value: IntLiteral{Value: 10}},
 		Op:    Sub,
 		Right: LiteralExpr{Value: FloatLiteral{Value: 3.2}},
 	}
 
-	_, err := interp.EvaluateExpression(expr, env)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "cannot subtract")
+	result, err := interp.EvaluateExpression(expr, env)
+	require.NoError(t, err)
+	assert.InDelta(t, 6.8, result.(float64), 0.001)
 }
 
 func TestEvaluateSub_UnsupportedType(t *testing.T) {
@@ -1554,14 +1555,16 @@ func TestEvaluateMul_TypeMismatch(t *testing.T) {
 	interp := NewInterpreter()
 	env := NewEnvironment()
 
+	// int * float now coerces int to float (consistent with Add)
 	expr := BinaryOpExpr{
 		Left:  LiteralExpr{Value: IntLiteral{Value: 5}},
 		Op:    Mul,
 		Right: LiteralExpr{Value: FloatLiteral{Value: 2.0}},
 	}
 
-	_, err := interp.EvaluateExpression(expr, env)
-	assert.Error(t, err)
+	result, err := interp.EvaluateExpression(expr, env)
+	require.NoError(t, err)
+	assert.Equal(t, float64(10.0), result)
 }
 
 func TestEvaluateMul_UnsupportedType(t *testing.T) {
@@ -1612,14 +1615,16 @@ func TestEvaluateDiv_TypeMismatch(t *testing.T) {
 	interp := NewInterpreter()
 	env := NewEnvironment()
 
+	// int / float now coerces int to float (consistent with Add)
 	expr := BinaryOpExpr{
 		Left:  LiteralExpr{Value: IntLiteral{Value: 10}},
 		Op:    Div,
 		Right: LiteralExpr{Value: FloatLiteral{Value: 2.0}},
 	}
 
-	_, err := interp.EvaluateExpression(expr, env)
-	assert.Error(t, err)
+	result, err := interp.EvaluateExpression(expr, env)
+	require.NoError(t, err)
+	assert.Equal(t, float64(5.0), result)
 }
 
 // Comparison operators with floats
@@ -1643,14 +1648,16 @@ func TestEvaluateLt_TypeMismatch(t *testing.T) {
 	interp := NewInterpreter()
 	env := NewEnvironment()
 
+	// int < float now coerces int to float (consistent with Eq)
 	expr := BinaryOpExpr{
 		Left:  LiteralExpr{Value: IntLiteral{Value: 5}},
 		Op:    Lt,
 		Right: LiteralExpr{Value: FloatLiteral{Value: 3.0}},
 	}
 
-	_, err := interp.EvaluateExpression(expr, env)
-	assert.Error(t, err)
+	result, err := interp.EvaluateExpression(expr, env)
+	require.NoError(t, err)
+	assert.Equal(t, false, result) // 5.0 < 3.0 is false
 }
 
 func TestEvaluateLt_UnsupportedType(t *testing.T) {
@@ -1686,14 +1693,16 @@ func TestEvaluateLe_TypeMismatch(t *testing.T) {
 	interp := NewInterpreter()
 	env := NewEnvironment()
 
+	// float <= int now coerces int to float (consistent with Eq)
 	expr := BinaryOpExpr{
 		Left:  LiteralExpr{Value: FloatLiteral{Value: 5.0}},
 		Op:    Le,
 		Right: LiteralExpr{Value: IntLiteral{Value: 5}},
 	}
 
-	_, err := interp.EvaluateExpression(expr, env)
-	assert.Error(t, err)
+	result, err := interp.EvaluateExpression(expr, env)
+	require.NoError(t, err)
+	assert.Equal(t, true, result) // 5.0 <= 5.0 is true
 }
 
 func TestEvaluateGt_Float(t *testing.T) {


### PR DESCRIPTION
## Summary
- Fix inconsistent numeric type coercion where Add/Eq allowed int-to-float promotion but Sub/Mul/Div/Lt/Le/Gt/Ge rejected it
- All numeric operators now consistently promote int to float when operands are mixed
- Closes #122

## Changes
- Modified 7 functions in `pkg/interpreter/evaluator.go`: `evaluateSub`, `evaluateMul`, `evaluateDiv`, `evaluateLt`, `evaluateLe`, `evaluateGt`, `evaluateGe`
- Changed `coerced` flag check to `_` (discard) in each function, matching existing behavior in `evaluateAdd`
- Updated 11 tests in `coercion_test.go` and `interpreter_test.go` to expect successful coercion instead of errors

## Test Plan
- [x] All 17 coercion tests pass with new expected values
- [x] Full test suite (47 packages) passes with `-race` detector
- [x] Division by zero still properly detected after coercion
- [x] String/bool type mismatches still correctly rejected
- [x] `go vet ./...` and `gofmt -l .` clean