### PR TITLE
feat: Add modulo/remainder operator (%)

### DIFF
--- a/pkg/ast/ast.go
+++ b/pkg/ast/ast.go
@@ -524,6 +524,7 @@ const (
 	Ge
 	And
 	Or
+	Mod
 )
 
 func (op BinOp) String() string {
@@ -552,6 +553,8 @@ func (op BinOp) String() string {
 		return "&&"
 	case Or:
 		return "||"
+	case Mod:
+		return "%"
 	default:
 		return "UNKNOWN"
 	}

--- a/pkg/compiler/compiler.go
+++ b/pkg/compiler/compiler.go
@@ -802,6 +802,8 @@ func (c *Compiler) compileBinaryOp(expr *ast.BinaryOpExpr) error {
 		c.emit(vm.OpMul)
 	case ast.Div:
 		c.emit(vm.OpDiv)
+	case ast.Mod:
+		c.emit(vm.OpMod)
 	case ast.Eq:
 		c.emit(vm.OpEq)
 	case ast.Ne:

--- a/pkg/compiler/optimizer.go
+++ b/pkg/compiler/optimizer.go
@@ -2,6 +2,8 @@ package compiler
 
 import (
 	"fmt"
+	"math"
+
 	"github.com/glyphlang/glyph/pkg/ast"
 )
 
@@ -551,6 +553,11 @@ func (o *Optimizer) foldLiteralBinaryOp(op ast.BinOp, left, right *ast.LiteralEx
 				result = leftInt.Value / rightInt.Value
 				return &ast.LiteralExpr{Value: ast.IntLiteral{Value: result}}
 			}
+		case ast.Mod:
+			if rightInt.Value != 0 {
+				result = leftInt.Value % rightInt.Value
+				return &ast.LiteralExpr{Value: ast.IntLiteral{Value: result}}
+			}
 		}
 
 		// Comparison operations on integers
@@ -590,6 +597,11 @@ func (o *Optimizer) foldLiteralBinaryOp(op ast.BinOp, left, right *ast.LiteralEx
 		case ast.Div:
 			if rightFloat.Value != 0 {
 				result = leftFloat.Value / rightFloat.Value
+				return &ast.LiteralExpr{Value: ast.FloatLiteral{Value: result}}
+			}
+		case ast.Mod:
+			if rightFloat.Value != 0 {
+				result = math.Mod(leftFloat.Value, rightFloat.Value)
 				return &ast.LiteralExpr{Value: ast.FloatLiteral{Value: result}}
 			}
 		}

--- a/pkg/decompiler/decompiler.go
+++ b/pkg/decompiler/decompiler.go
@@ -333,6 +333,7 @@ func opcodeToString(op vm.Opcode) string {
 		vm.OpSub:             "SUB",
 		vm.OpMul:             "MUL",
 		vm.OpDiv:             "DIV",
+		vm.OpMod:             "MOD",
 		vm.OpEq:              "EQ",
 		vm.OpNe:              "NE",
 		vm.OpLt:              "LT",

--- a/pkg/interpreter/evaluator.go
+++ b/pkg/interpreter/evaluator.go
@@ -4,6 +4,7 @@ import (
 	. "github.com/glyphlang/glyph/pkg/ast"
 
 	"fmt"
+	"math"
 	"strings"
 	"unicode"
 )
@@ -258,6 +259,8 @@ func (i *Interpreter) evaluateBinaryOp(expr BinaryOpExpr, env *Environment) (int
 		return i.evaluateMul(left, right)
 	case Div:
 		return i.evaluateDiv(left, right)
+	case Mod:
+		return i.evaluateMod(left, right)
 	case Eq:
 		return i.evaluateEq(left, right)
 	case Ne:
@@ -432,6 +435,34 @@ func (i *Interpreter) evaluateDiv(left, right interface{}) (interface{}, error) 
 	}
 
 	return nil, fmt.Errorf("cannot divide %T and %T", left, right)
+}
+
+// evaluateMod handles modulo/remainder operation
+func (i *Interpreter) evaluateMod(left, right interface{}) (interface{}, error) {
+	// Numeric modulo with automatic coercion (int->float promotion)
+	coercedLeft, coercedRight, _ := CoerceNumeric(left, right)
+
+	// Integer modulo
+	if leftInt, ok := coercedLeft.(int64); ok {
+		if rightInt, ok := coercedRight.(int64); ok {
+			if rightInt == 0 {
+				return nil, fmt.Errorf("modulo by zero")
+			}
+			return leftInt % rightInt, nil
+		}
+	}
+
+	// Float modulo
+	if leftFloat, ok := coercedLeft.(float64); ok {
+		if rightFloat, ok := coercedRight.(float64); ok {
+			if rightFloat == 0 {
+				return nil, fmt.Errorf("modulo by zero")
+			}
+			return math.Mod(leftFloat, rightFloat), nil
+		}
+	}
+
+	return nil, fmt.Errorf("cannot compute modulo of %T and %T", left, right)
 }
 
 // evaluateEq handles equality comparison

--- a/pkg/interpreter/modulo_test.go
+++ b/pkg/interpreter/modulo_test.go
@@ -1,0 +1,131 @@
+package interpreter
+
+import (
+	. "github.com/glyphlang/glyph/pkg/ast"
+
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestModulo_IntegerBasic(t *testing.T) {
+	interp := NewInterpreter()
+	env := NewEnvironment()
+
+	expr := BinaryOpExpr{
+		Left:  LiteralExpr{Value: IntLiteral{Value: 10}},
+		Op:    Mod,
+		Right: LiteralExpr{Value: IntLiteral{Value: 3}},
+	}
+
+	result, err := interp.EvaluateExpression(expr, env)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), result)
+}
+
+func TestModulo_IntegerExact(t *testing.T) {
+	interp := NewInterpreter()
+	env := NewEnvironment()
+
+	expr := BinaryOpExpr{
+		Left:  LiteralExpr{Value: IntLiteral{Value: 9}},
+		Op:    Mod,
+		Right: LiteralExpr{Value: IntLiteral{Value: 3}},
+	}
+
+	result, err := interp.EvaluateExpression(expr, env)
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), result)
+}
+
+func TestModulo_FloatBasic(t *testing.T) {
+	interp := NewInterpreter()
+	env := NewEnvironment()
+
+	expr := BinaryOpExpr{
+		Left:  LiteralExpr{Value: FloatLiteral{Value: 10.5}},
+		Op:    Mod,
+		Right: LiteralExpr{Value: FloatLiteral{Value: 3.0}},
+	}
+
+	result, err := interp.EvaluateExpression(expr, env)
+	require.NoError(t, err)
+	assert.InDelta(t, 1.5, result.(float64), 0.001)
+}
+
+func TestModulo_IntAndFloat(t *testing.T) {
+	interp := NewInterpreter()
+	env := NewEnvironment()
+
+	// int % float should coerce int to float
+	expr := BinaryOpExpr{
+		Left:  LiteralExpr{Value: IntLiteral{Value: 10}},
+		Op:    Mod,
+		Right: LiteralExpr{Value: FloatLiteral{Value: 3.0}},
+	}
+
+	result, err := interp.EvaluateExpression(expr, env)
+	require.NoError(t, err)
+	assert.InDelta(t, 1.0, result.(float64), 0.001)
+}
+
+func TestModulo_ByZero_Int(t *testing.T) {
+	interp := NewInterpreter()
+	env := NewEnvironment()
+
+	expr := BinaryOpExpr{
+		Left:  LiteralExpr{Value: IntLiteral{Value: 10}},
+		Op:    Mod,
+		Right: LiteralExpr{Value: IntLiteral{Value: 0}},
+	}
+
+	_, err := interp.EvaluateExpression(expr, env)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "modulo by zero")
+}
+
+func TestModulo_ByZero_Float(t *testing.T) {
+	interp := NewInterpreter()
+	env := NewEnvironment()
+
+	expr := BinaryOpExpr{
+		Left:  LiteralExpr{Value: FloatLiteral{Value: 10.5}},
+		Op:    Mod,
+		Right: LiteralExpr{Value: FloatLiteral{Value: 0.0}},
+	}
+
+	_, err := interp.EvaluateExpression(expr, env)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "modulo by zero")
+}
+
+func TestModulo_NegativeInt(t *testing.T) {
+	interp := NewInterpreter()
+	env := NewEnvironment()
+
+	// Go's % operator preserves the sign of the dividend
+	expr := BinaryOpExpr{
+		Left:  LiteralExpr{Value: IntLiteral{Value: -10}},
+		Op:    Mod,
+		Right: LiteralExpr{Value: IntLiteral{Value: 3}},
+	}
+
+	result, err := interp.EvaluateExpression(expr, env)
+	require.NoError(t, err)
+	assert.Equal(t, int64(-1), result)
+}
+
+func TestModulo_UnsupportedType(t *testing.T) {
+	interp := NewInterpreter()
+	env := NewEnvironment()
+
+	expr := BinaryOpExpr{
+		Left:  LiteralExpr{Value: StringLiteral{Value: "hello"}},
+		Op:    Mod,
+		Right: LiteralExpr{Value: IntLiteral{Value: 3}},
+	}
+
+	_, err := interp.EvaluateExpression(expr, env)
+	assert.Error(t, err)
+}

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -2512,6 +2512,8 @@ func (p *Parser) currentBinaryOp() (ast.BinOp, int) {
 		return ast.Mul, 20
 	case SLASH:
 		return ast.Div, 20
+	case PERCENT:
+		return ast.Mod, 20
 	case EQ_EQ:
 		return ast.Eq, 5
 	case NOT_EQ:
@@ -2592,6 +2594,8 @@ func (p *Parser) currentCommandDefaultBinaryOp() (ast.BinOp, int) {
 		return ast.Mul, 20
 	case SLASH:
 		return ast.Div, 20
+	case PERCENT:
+		return ast.Mod, 20
 	case EQ_EQ:
 		return ast.Eq, 5
 	case NOT_EQ:


### PR DESCRIPTION
## Summary
- Implement the `%` (modulo/remainder) operator across all language layers
- Closes #124

## Changes
- **AST**: Added `Mod` constant to `BinOp` enum with `%` string representation
- **Parser**: Added `PERCENT` token recognition in `currentBinaryOp()` and `currentCommandDefaultBinaryOp()` with precedence 20 (same as `*` and `/`)
- **Interpreter**: Added `evaluateMod()` function with int64 (`%` operator) and float64 (`math.Mod`) support, including modulo-by-zero detection
- **Compiler**: Added `ast.Mod` → `vm.OpMod` emission in `compileBinaryOp()`
- **VM**: Added `OpMod` opcode (0x14) and `execMod()` with int/float type handling
- **Optimizer**: Added constant folding for integer and float modulo in both literal sections
- **Decompiler**: Added `OpMod` → `"MOD"` name mapping

## Test Plan
- [x] 8 new interpreter tests covering int, float, mixed types, zero divisor, negative values, and type errors
- [x] Full test suite (47 packages) passes with `-race` detector
- [x] `go vet ./...` and `gofmt -l .` clean