### PR TITLE
feat: Add break and continue statements

### DIFF
--- a/pkg/ast/ast.go
+++ b/pkg/ast/ast.go
@@ -278,6 +278,16 @@ type ReturnStatement struct {
 
 func (ReturnStatement) isStatement() {}
 
+// BreakStatement represents a break statement to exit a loop
+type BreakStatement struct{}
+
+func (BreakStatement) isStatement() {}
+
+// ContinueStatement represents a continue statement to skip to next loop iteration
+type ContinueStatement struct{}
+
+func (ContinueStatement) isStatement() {}
+
 // IfStatement represents an if statement
 type IfStatement struct {
 	Condition Expr
@@ -972,6 +982,8 @@ func (MacroInvocation) isNode()      {}
 func (AssignStatement) isNode()      {}
 func (DbQueryStatement) isNode()     {}
 func (ReturnStatement) isNode()      {}
+func (BreakStatement) isNode()       {}
+func (ContinueStatement) isNode()    {}
 func (IfStatement) isNode()          {}
 func (WhileStatement) isNode()       {}
 func (SwitchStatement) isNode()      {}

--- a/pkg/interpreter/break_continue_test.go
+++ b/pkg/interpreter/break_continue_test.go
@@ -1,0 +1,245 @@
+package interpreter
+
+import (
+	. "github.com/glyphlang/glyph/pkg/ast"
+
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBreak_WhileLoop(t *testing.T) {
+	interp := NewInterpreter()
+	env := NewEnvironment()
+
+	// $count = 0
+	// while true {
+	//   $count = $count + 1
+	//   if $count == 3 { break }
+	// }
+	env.Define("count", int64(0))
+
+	stmts := []Statement{
+		WhileStatement{
+			Condition: LiteralExpr{Value: BoolLiteral{Value: true}},
+			Body: []Statement{
+				ReassignStatement{
+					Target: "count",
+					Value: BinaryOpExpr{
+						Left:  VariableExpr{Name: "count"},
+						Op:    Add,
+						Right: LiteralExpr{Value: IntLiteral{Value: 1}},
+					},
+				},
+				IfStatement{
+					Condition: BinaryOpExpr{
+						Left:  VariableExpr{Name: "count"},
+						Op:    Eq,
+						Right: LiteralExpr{Value: IntLiteral{Value: 3}},
+					},
+					ThenBlock: []Statement{
+						BreakStatement{},
+					},
+				},
+			},
+		},
+	}
+
+	_, err := interp.executeStatements(stmts, env)
+	require.NoError(t, err)
+
+	count, err := env.Get("count")
+	require.NoError(t, err)
+	assert.Equal(t, int64(3), count)
+}
+
+func TestContinue_WhileLoop(t *testing.T) {
+	interp := NewInterpreter()
+	env := NewEnvironment()
+
+	// $count = 0
+	// $sum = 0
+	// while $count < 5 {
+	//   $count = $count + 1
+	//   if $count == 3 { continue }  // skip adding 3
+	//   $sum = $sum + $count
+	// }
+	env.Define("count", int64(0))
+	env.Define("sum", int64(0))
+
+	stmts := []Statement{
+		WhileStatement{
+			Condition: BinaryOpExpr{
+				Left:  VariableExpr{Name: "count"},
+				Op:    Lt,
+				Right: LiteralExpr{Value: IntLiteral{Value: 5}},
+			},
+			Body: []Statement{
+				ReassignStatement{
+					Target: "count",
+					Value: BinaryOpExpr{
+						Left:  VariableExpr{Name: "count"},
+						Op:    Add,
+						Right: LiteralExpr{Value: IntLiteral{Value: 1}},
+					},
+				},
+				IfStatement{
+					Condition: BinaryOpExpr{
+						Left:  VariableExpr{Name: "count"},
+						Op:    Eq,
+						Right: LiteralExpr{Value: IntLiteral{Value: 3}},
+					},
+					ThenBlock: []Statement{
+						ContinueStatement{},
+					},
+				},
+				ReassignStatement{
+					Target: "sum",
+					Value: BinaryOpExpr{
+						Left:  VariableExpr{Name: "sum"},
+						Op:    Add,
+						Right: VariableExpr{Name: "count"},
+					},
+				},
+			},
+		},
+	}
+
+	_, err := interp.executeStatements(stmts, env)
+	require.NoError(t, err)
+
+	sum, err := env.Get("sum")
+	require.NoError(t, err)
+	// sum = 1 + 2 + 4 + 5 = 12 (skipping 3)
+	assert.Equal(t, int64(12), sum)
+}
+
+func TestBreak_ForLoop(t *testing.T) {
+	interp := NewInterpreter()
+	env := NewEnvironment()
+
+	// $result = 0
+	// for item in [10, 20, 30, 40, 50] {
+	//   if $item == 30 { break }
+	//   $result = $result + $item
+	// }
+	env.Define("result", int64(0))
+
+	stmts := []Statement{
+		ForStatement{
+			ValueVar: "item",
+			Iterable: ArrayExpr{
+				Elements: []Expr{
+					LiteralExpr{Value: IntLiteral{Value: 10}},
+					LiteralExpr{Value: IntLiteral{Value: 20}},
+					LiteralExpr{Value: IntLiteral{Value: 30}},
+					LiteralExpr{Value: IntLiteral{Value: 40}},
+					LiteralExpr{Value: IntLiteral{Value: 50}},
+				},
+			},
+			Body: []Statement{
+				IfStatement{
+					Condition: BinaryOpExpr{
+						Left:  VariableExpr{Name: "item"},
+						Op:    Eq,
+						Right: LiteralExpr{Value: IntLiteral{Value: 30}},
+					},
+					ThenBlock: []Statement{
+						BreakStatement{},
+					},
+				},
+				ReassignStatement{
+					Target: "result",
+					Value: BinaryOpExpr{
+						Left:  VariableExpr{Name: "result"},
+						Op:    Add,
+						Right: VariableExpr{Name: "item"},
+					},
+				},
+			},
+		},
+	}
+
+	_, err := interp.executeStatements(stmts, env)
+	require.NoError(t, err)
+
+	result, err := env.Get("result")
+	require.NoError(t, err)
+	// result = 10 + 20 = 30 (broke at 30)
+	assert.Equal(t, int64(30), result)
+}
+
+func TestContinue_ForLoop(t *testing.T) {
+	interp := NewInterpreter()
+	env := NewEnvironment()
+
+	// $result = 0
+	// for item in [1, 2, 3, 4, 5] {
+	//   if $item == 3 { continue }  // skip 3
+	//   $result = $result + $item
+	// }
+	env.Define("result", int64(0))
+
+	stmts := []Statement{
+		ForStatement{
+			ValueVar: "item",
+			Iterable: ArrayExpr{
+				Elements: []Expr{
+					LiteralExpr{Value: IntLiteral{Value: 1}},
+					LiteralExpr{Value: IntLiteral{Value: 2}},
+					LiteralExpr{Value: IntLiteral{Value: 3}},
+					LiteralExpr{Value: IntLiteral{Value: 4}},
+					LiteralExpr{Value: IntLiteral{Value: 5}},
+				},
+			},
+			Body: []Statement{
+				IfStatement{
+					Condition: BinaryOpExpr{
+						Left:  VariableExpr{Name: "item"},
+						Op:    Eq,
+						Right: LiteralExpr{Value: IntLiteral{Value: 3}},
+					},
+					ThenBlock: []Statement{
+						ContinueStatement{},
+					},
+				},
+				ReassignStatement{
+					Target: "result",
+					Value: BinaryOpExpr{
+						Left:  VariableExpr{Name: "result"},
+						Op:    Add,
+						Right: VariableExpr{Name: "item"},
+					},
+				},
+			},
+		},
+	}
+
+	_, err := interp.executeStatements(stmts, env)
+	require.NoError(t, err)
+
+	result, err := env.Get("result")
+	require.NoError(t, err)
+	// result = 1 + 2 + 4 + 5 = 12 (skipping 3)
+	assert.Equal(t, int64(12), result)
+}
+
+func TestBreak_ImmediateInWhile(t *testing.T) {
+	interp := NewInterpreter()
+	env := NewEnvironment()
+
+	// while true { break }
+	// Should not loop forever
+	stmts := []Statement{
+		WhileStatement{
+			Condition: LiteralExpr{Value: BoolLiteral{Value: true}},
+			Body: []Statement{
+				BreakStatement{},
+			},
+		},
+	}
+
+	_, err := interp.executeStatements(stmts, env)
+	require.NoError(t, err)
+}

--- a/pkg/interpreter/executor.go
+++ b/pkg/interpreter/executor.go
@@ -16,6 +16,20 @@ func (r *returnValue) Error() string {
 	return "return"
 }
 
+// breakValue is a special error type to handle break statements (same pattern as returnValue above)
+type breakValue struct{}
+
+func (b *breakValue) Error() string {
+	return "break"
+}
+
+// continueValue is a special error type to handle continue statements (same pattern as returnValue above)
+type continueValue struct{}
+
+func (c *continueValue) Error() string {
+	return "continue"
+}
+
 // AssertionError represents a failed test assertion
 type AssertionError struct {
 	Message string
@@ -88,6 +102,12 @@ func (i *Interpreter) ExecuteStatement(stmt Statement, env *Environment) (interf
 
 	case ExpressionStatement:
 		return i.EvaluateExpression(s.Expr, env)
+
+	case BreakStatement:
+		return nil, &breakValue{}
+
+	case ContinueStatement:
+		return nil, &continueValue{}
 
 	default:
 		return nil, fmt.Errorf("unsupported statement type: %T", stmt)
@@ -296,6 +316,12 @@ func (i *Interpreter) executeWhile(stmt WhileStatement, env *Environment) (inter
 		// Execute loop body
 		result, err = i.executeStatements(stmt.Body, loopEnv)
 		if err != nil {
+			if _, isBreak := err.(*breakValue); isBreak {
+				break
+			}
+			if _, isContinue := err.(*continueValue); isContinue {
+				continue
+			}
 			// Check if it's a return statement
 			if _, isReturn := err.(*returnValue); isReturn {
 				return result, err
@@ -333,6 +359,12 @@ func (i *Interpreter) executeFor(stmt ForStatement, env *Environment) (interface
 			// Execute loop body
 			result, err = i.executeStatements(stmt.Body, loopEnv)
 			if err != nil {
+				if _, isBreak := err.(*breakValue); isBreak {
+					return result, nil
+				}
+				if _, isContinue := err.(*continueValue); isContinue {
+					continue
+				}
 				// Check if it's a return statement
 				if _, isReturn := err.(*returnValue); isReturn {
 					return result, err
@@ -358,6 +390,12 @@ func (i *Interpreter) executeFor(stmt ForStatement, env *Environment) (interface
 			// Execute loop body
 			result, err = i.executeStatements(stmt.Body, loopEnv)
 			if err != nil {
+				if _, isBreak := err.(*breakValue); isBreak {
+					return result, nil
+				}
+				if _, isContinue := err.(*continueValue); isContinue {
+					continue
+				}
 				// Check if it's a return statement
 				if _, isReturn := err.(*returnValue); isReturn {
 					return result, err

--- a/pkg/parser/lexer.go
+++ b/pkg/parser/lexer.go
@@ -401,6 +401,10 @@ func (l *Lexer) readIdentifier() Token {
 		tok.Type = CONST
 	case "assert":
 		tok.Type = ASSERT
+	case "break":
+		tok.Type = BREAK
+	case "continue":
+		tok.Type = CONTINUE
 	default:
 		tok.Type = IDENT
 	}

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -2054,6 +2054,14 @@ func (p *Parser) parseStatement() (ast.Statement, error) {
 	case FOR:
 		return p.parseForStatement()
 
+	case BREAK:
+		p.advance() // consume "break"
+		return ast.BreakStatement{}, nil
+
+	case CONTINUE:
+		p.advance() // consume "continue"
+		return ast.ContinueStatement{}, nil
+
 	default:
 		return nil, p.errorWithHint(
 			fmt.Sprintf("Expected statement, but found %s", p.current().Type),

--- a/pkg/parser/token.go
+++ b/pkg/parser/token.go
@@ -76,6 +76,8 @@ const (
 	CONST     // const
 	TEST      // test
 	ASSERT    // assert
+	BREAK     // break
+	CONTINUE  // continue
 )
 
 // Token represents a lexical token
@@ -215,6 +217,10 @@ func (t TokenType) String() string {
 		return "TEST"
 	case ASSERT:
 		return "ASSERT"
+	case BREAK:
+		return "BREAK"
+	case CONTINUE:
+		return "CONTINUE"
 	default:
 		return "UNKNOWN"
 	}


### PR DESCRIPTION
## Summary
- Implements `break` and `continue` flow control statements for while and for loops
- Closes #123

## Changes
- Added `BREAK` and `CONTINUE` tokens to lexer keyword recognition
- Added `BreakStatement` and `ContinueStatement` AST node types
- Added parser cases for `break` and `continue` keywords
- Implemented `breakValue` and `continueValue` sentinel error types (following existing `returnValue` pattern)
- Updated `executeWhile()` and `executeFor()` to handle break/continue signals
- Break exits the innermost loop; continue skips to the next iteration

## Test Plan
- `TestBreak_WhileLoop` — break exits while loop at correct iteration
- `TestContinue_WhileLoop` — continue skips iteration in while loop
- `TestBreak_ForLoop` — break exits for-in loop early
- `TestContinue_ForLoop` — continue skips element in for-in loop
- `TestBreak_ImmediateInWhile` — immediate break in `while true` doesn't hang
- Full test suite passes with race detector: `go test -race ./...`