### PR TITLE
fix: Skip StaticRoute items in interpreter LoadModule

### DIFF
--- a/pkg/interpreter/coverage_test.go
+++ b/pkg/interpreter/coverage_test.go
@@ -336,6 +336,24 @@ func TestLoadModuleWithQueueWorker(t *testing.T) {
 	}
 }
 
+func TestLoadModuleWithStaticRoute(t *testing.T) {
+	interp := NewInterpreter()
+
+	module := Module{
+		Items: []Item{
+			&StaticRoute{
+				Path:    "/assets",
+				RootDir: "./public",
+			},
+		},
+	}
+
+	err := interp.LoadModule(module)
+	if err != nil {
+		t.Errorf("LoadModule with static route failed: %v", err)
+	}
+}
+
 // TestDbQueryStatement tests db query statement execution
 func TestDbQueryStatement(t *testing.T) {
 	interp := NewInterpreter()

--- a/pkg/interpreter/interpreter.go
+++ b/pkg/interpreter/interpreter.go
@@ -198,6 +198,10 @@ func (i *Interpreter) LoadModuleWithPath(module Module, basePath string) error {
 			i.globalEnv.Define(it.Name, value)
 			i.constants[it.Name] = struct{}{}
 
+		case *StaticRoute:
+			// Static routes are handled at the server/mux level, not by the interpreter.
+			continue
+
 		default:
 			return fmt.Errorf("unsupported item type: %T", item)
 		}


### PR DESCRIPTION
## Summary
- Fixes `unsupported item type: *ast.StaticRoute` error when loading modules that use `@ static`
- The interpreter's `LoadModule` now skips `StaticRoute` items since they're handled at the server/mux level

## Changes
- **`pkg/interpreter/interpreter.go`**: Add `case *StaticRoute: continue` to the `LoadModule` item switch
- **`pkg/interpreter/coverage_test.go`**: Add `TestLoadModuleWithStaticRoute` verifying modules with static routes load without error

## Test Plan
- [x] `go build ./...` succeeds
- [x] `go test -race ./...` all pass
- [x] `go vet ./...` clean
- [x] Manually verified: `glyph run examples/mtg-server/main.glyph` starts successfully with static file serving