### PR TITLE
feat: Add provider parser syntax

### DIFF
--- a/docs/POLYGLOT_ROADMAP.md
+++ b/docs/POLYGLOT_ROADMAP.md
@@ -22,15 +22,16 @@ The Semantic IR, generalized provider system, and Python/FastAPI codegen are mer
 - [x] Support `--lang python` flag (extensible for future targets)
 - [x] Generate project structure: `main.py`, `requirements.txt`
 
-## Phase 2: Provider Parser Syntax
+## Phase 2: Provider Parser Syntax (complete)
 
 **Goal**: Parse `provider` declarations in .glyph source files.
 
-- [ ] Add `provider` keyword to lexer (both compact and expanded)
-- [ ] Add parser rule for `provider Name { method(...): ReturnType }` blocks
-- [ ] Produce `ProviderDef` AST nodes from parsed source
-- [ ] Add validation in the `validate` command
-- [ ] Add examples demonstrating custom providers
+- [x] Add `provider` keyword to parser (IDENT-based, no compact symbol needed)
+- [x] Add parser rule for `provider Name { method(params) -> ReturnType }` blocks
+- [x] Produce `ProviderDef` AST nodes from parsed source (AST types already existed)
+- [x] Wire `ProviderDef` through IR analyzer with method signatures
+- [x] Add validation in the `validate` command (duplicate detection, method type checking, injection validation)
+- [x] Add examples demonstrating custom providers (`examples/custom-provider/`)
 
 ## Phase 3: Second Target Language
 

--- a/examples/custom-provider/main.glyph
+++ b/examples/custom-provider/main.glyph
@@ -1,0 +1,91 @@
+# Custom Provider Example
+# Demonstrates declaring and using custom provider contracts
+
+# --- Types ---
+
+: EmailMessage {
+  to: str!
+  subject: str!
+  body: str!
+}
+
+: EmailStatus {
+  id: str!
+  status: str!
+  delivered_at: str
+}
+
+: ChargeResult {
+  id: str!
+  amount: int!
+  currency: str!
+  status: str!
+}
+
+: RefundResult {
+  id: str!
+  charge_id: str!
+  status: str!
+}
+
+: NotificationPayload {
+  user_id: str!
+  message: str!
+  channel: str!
+}
+
+# --- Provider Contracts ---
+
+# Email service provider for sending transactional emails.
+# At codegen time, this generates a stub class with these methods.
+provider EmailService {
+  send(to: str!, subject: str!, body: str!) -> EmailStatus
+  status(message_id: str!) -> EmailStatus
+}
+
+# Payment gateway provider for processing charges and refunds.
+provider PaymentGateway {
+  charge(amount: int!, currency: str!, token: str!) -> ChargeResult
+  refund(charge_id: str!) -> RefundResult
+}
+
+# Notification provider (no return type on send).
+provider Notifier {
+  send(payload: NotificationPayload)
+}
+
+# --- Routes ---
+
+@ POST /api/email/send {
+  < input: EmailMessage
+  % email: EmailService
+  $ result = email.send(input.to, input.subject, input.body)
+  > result
+}
+
+@ GET /api/email/status/:id -> EmailStatus {
+  % email: EmailService
+  $ result = email.status(id)
+  > result
+}
+
+@ POST /api/payments/charge {
+  < input: ChargeResult
+  % payments: PaymentGateway
+  $ result = payments.charge(input.amount, input.currency, "tok_test")
+  > result
+}
+
+@ POST /api/payments/refund/:charge_id -> RefundResult {
+  % payments: PaymentGateway
+  $ result = payments.refund(charge_id)
+  > result
+}
+
+@ POST /api/notify/:user_id {
+  % notifier: Notifier
+  % db: Database
+  $ payload = { user_id: user_id, message: "Hello", channel: "push" }
+  $ result = notifier.send(payload)
+  > { success: true }
+}

--- a/pkg/parser/provider_test.go
+++ b/pkg/parser/provider_test.go
@@ -1,0 +1,179 @@
+package parser
+
+import (
+	"testing"
+
+	"github.com/glyphlang/glyph/pkg/ast"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func lexProviderSource(source string) []Token {
+	lexer := NewLexer(source)
+	tokens, _ := lexer.Tokenize()
+	return tokens
+}
+
+func lexExpandedProviderSource(source string) []Token {
+	lexer := NewExpandedLexer(source)
+	tokens, _ := lexer.Tokenize()
+	return tokens
+}
+
+// TestProviderDefinition tests parsing a basic provider definition
+func TestProviderDefinition(t *testing.T) {
+	source := `provider EmailService {
+  send(to: str!, subject: str!, body: str!) -> bool
+  status(messageId: str!) -> str
+}`
+	tokens := lexProviderSource(source)
+	parser := NewParser(tokens)
+	module, err := parser.Parse()
+	require.NoError(t, err)
+	require.Len(t, module.Items, 1)
+
+	prov, ok := module.Items[0].(*ast.ProviderDef)
+	require.True(t, ok, "expected ProviderDef")
+	assert.Equal(t, "EmailService", prov.Name)
+	require.Len(t, prov.Methods, 2)
+
+	assert.Equal(t, "send", prov.Methods[0].Name)
+	require.Len(t, prov.Methods[0].Params, 3)
+	assert.Equal(t, "to", prov.Methods[0].Params[0].Name)
+	assert.Equal(t, "subject", prov.Methods[0].Params[1].Name)
+	assert.Equal(t, "body", prov.Methods[0].Params[2].Name)
+
+	assert.Equal(t, "status", prov.Methods[1].Name)
+	require.Len(t, prov.Methods[1].Params, 1)
+	assert.Equal(t, "messageId", prov.Methods[1].Params[0].Name)
+}
+
+// TestProviderDefinitionExpandedSyntax tests provider parsing with expanded lexer
+func TestProviderDefinitionExpandedSyntax(t *testing.T) {
+	source := `provider PaymentGateway {
+  charge(amount: int!, currency: str!) -> str
+}`
+	tokens := lexExpandedProviderSource(source)
+	parser := NewParser(tokens)
+	module, err := parser.Parse()
+	require.NoError(t, err)
+	require.Len(t, module.Items, 1)
+
+	prov, ok := module.Items[0].(*ast.ProviderDef)
+	require.True(t, ok)
+	assert.Equal(t, "PaymentGateway", prov.Name)
+	require.Len(t, prov.Methods, 1)
+	assert.Equal(t, "charge", prov.Methods[0].Name)
+}
+
+// TestProviderWithGenericParams tests provider with generic type parameters
+func TestProviderWithGenericParams(t *testing.T) {
+	source := `provider Cache<T> {
+  get(key: str!) -> T
+  set(key: str!, value: T) -> bool
+  delete(key: str!) -> bool
+}`
+	tokens := lexProviderSource(source)
+	parser := NewParser(tokens)
+	module, err := parser.Parse()
+	require.NoError(t, err)
+	require.Len(t, module.Items, 1)
+
+	prov, ok := module.Items[0].(*ast.ProviderDef)
+	require.True(t, ok)
+	assert.Equal(t, "Cache", prov.Name)
+	require.Len(t, prov.TypeParams, 1)
+	assert.Equal(t, "T", prov.TypeParams[0].Name)
+	require.Len(t, prov.Methods, 3)
+}
+
+// TestProviderMethodNoReturnType tests provider method with no return type
+func TestProviderMethodNoReturnType(t *testing.T) {
+	source := `provider Logger {
+  log(msg: str!)
+}`
+	tokens := lexProviderSource(source)
+	parser := NewParser(tokens)
+	module, err := parser.Parse()
+	require.NoError(t, err)
+	require.Len(t, module.Items, 1)
+
+	prov, ok := module.Items[0].(*ast.ProviderDef)
+	require.True(t, ok)
+	require.Len(t, prov.Methods, 1)
+	assert.Equal(t, "log", prov.Methods[0].Name)
+	assert.Nil(t, prov.Methods[0].ReturnType)
+}
+
+// TestProviderWithTypeDefAndRoute tests provider alongside types and routes
+func TestProviderWithTypeDefAndRoute(t *testing.T) {
+	source := `: ChargeResult {
+  id: str
+  status: str
+}
+
+provider Payments {
+  charge(amount: int!, currency: str!) -> ChargeResult
+}
+
+@ GET /api/charge/:id -> ChargeResult {
+  % payments: Payments
+  $ result = payments.charge(100, "usd")
+  > result
+}`
+	tokens := lexProviderSource(source)
+	parser := NewParser(tokens)
+	module, err := parser.Parse()
+	require.NoError(t, err)
+	require.Len(t, module.Items, 3)
+
+	_, ok := module.Items[0].(*ast.TypeDef)
+	require.True(t, ok, "expected TypeDef")
+
+	prov, ok := module.Items[1].(*ast.ProviderDef)
+	require.True(t, ok, "expected ProviderDef")
+	assert.Equal(t, "Payments", prov.Name)
+
+	route, ok := module.Items[2].(*ast.Route)
+	require.True(t, ok, "expected Route")
+	require.Len(t, route.Injections, 1)
+	assert.Equal(t, "payments", route.Injections[0].Name)
+}
+
+// TestProviderEmptyBody tests provider with no methods
+func TestProviderEmptyBody(t *testing.T) {
+	source := `provider Empty {
+}`
+	tokens := lexProviderSource(source)
+	parser := NewParser(tokens)
+	module, err := parser.Parse()
+	require.NoError(t, err)
+	require.Len(t, module.Items, 1)
+
+	prov, ok := module.Items[0].(*ast.ProviderDef)
+	require.True(t, ok)
+	assert.Equal(t, "Empty", prov.Name)
+	assert.Empty(t, prov.Methods)
+}
+
+// TestProviderMethodMultipleParams tests provider method with multiple parameters
+func TestProviderMethodMultipleParams(t *testing.T) {
+	source := `provider ImageProcessor {
+  resize(file: str!, width: int!, height: int!, quality: int) -> str
+}`
+	tokens := lexProviderSource(source)
+	parser := NewParser(tokens)
+	module, err := parser.Parse()
+	require.NoError(t, err)
+	require.Len(t, module.Items, 1)
+
+	prov, ok := module.Items[0].(*ast.ProviderDef)
+	require.True(t, ok)
+	require.Len(t, prov.Methods, 1)
+	assert.Equal(t, "resize", prov.Methods[0].Name)
+	require.Len(t, prov.Methods[0].Params, 4)
+	assert.Equal(t, "file", prov.Methods[0].Params[0].Name)
+	assert.Equal(t, "width", prov.Methods[0].Params[1].Name)
+	assert.Equal(t, "height", prov.Methods[0].Params[2].Name)
+	assert.Equal(t, "quality", prov.Methods[0].Params[3].Name)
+}


### PR DESCRIPTION
## Summary
- Add `provider` as a top-level keyword for declaring custom provider contracts in `.glyph` files
- Wire provider definitions through the IR analyzer with method signatures
- Add validation: duplicate detection, method type checking, injection type validation
- Completes Phase 2 of the polyglot roadmap

## Changes
- **Parser** (`pkg/parser/parser.go`): `parseProvider()` and `parseProviderMethod()` following the `parseTrait()` pattern, updated error hints
- **IR Analyzer** (`pkg/ir/analyzer.go`): `convertProviderDef()` with method signatures, provider contract lookup in `registerInjection()`
- **Validator** (`pkg/validate/validate.go`): Provider collection, duplicate detection, method type validation, injection validation against defined/builtin providers, added Redis/MongoDB/LLM to builtin types
- **Tests**: 7 parser tests, 2 IR analyzer tests, 5 validator tests — all new functions at 100% coverage
- **Example**: `examples/custom-provider/main.glyph` with EmailService, PaymentGateway, and Notifier providers
- **Roadmap**: Marked Phase 2 as complete

## Syntax

```glyph
provider EmailService {
  send(to: str!, subject: str!, body: str!) -> EmailStatus
  status(message_id: str!) -> EmailStatus
}

@ POST /api/email/send {
  % email: EmailService
  $ result = email.send(input.to, input.subject, input.body)
  > result
}
```

## Test plan
- [x] All 46 test packages pass with `-race`
- [x] All 43 example `.glyph` files validate cleanly
- [x] `go vet` and `gofmt` clean
- [x] `glyph validate examples/custom-provider/main.glyph` passes
- [x] `glyph codegen examples/custom-provider/main.glyph` generates correct Python with provider stubs