### PR TITLE
feat: Phase 6 — Expand IR coverage with WebSocket, GraphQL, gRPC, pattern matching, async/await codegen

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,15 +55,15 @@ installer: build-all
 # Test targets
 test:
 	@echo "Running Go tests..."
-	go test ./pkg/... -v
+	go test ./... -v
 
 test-short:
 	@echo "Running Go tests (short mode)..."
-	go test ./pkg/... -v -short
+	go test ./... -v -short
 
 test-coverage:
 	@echo "Running tests with coverage..."
-	go test ./pkg/... -coverprofile=coverage.out -covermode=atomic
+	go test ./... -coverprofile=coverage.out -covermode=atomic
 	go tool cover -html=coverage.out -o coverage.html
 	@echo "Coverage report: coverage.html"
 

--- a/docs/POLYGLOT_ROADMAP.md
+++ b/docs/POLYGLOT_ROADMAP.md
@@ -52,7 +52,7 @@ The Semantic IR, generalized provider system, and Python/FastAPI codegen are mer
 - [x] Parse each intent-test .glyph → IR → Python, verify output structure (`tests/codegen_integration_test.go`)
 - [x] Parse each intent-test .glyph → IR → TypeScript, verify output structure
 - [x] Regression tests: both targets tested against all 5 intent-test files + custom-provider example
-- [ ] Add to CI pipeline
+- [x] Add to CI pipeline (included via `go test ./...` in CI workflow and Makefile)
 
 ## Phase 5: Intent Hypothesis Testing
 
@@ -64,15 +64,15 @@ The Semantic IR, generalized provider system, and Python/FastAPI codegen are mer
 - [ ] Compare results across the 5 intent-test scenarios
 - [ ] Document findings
 
-## Phase 6: Expand IR Coverage
+## Phase 6: Expand IR Coverage (complete)
 
 **Goal**: Handle all Glyph language features in the IR.
 
-- [ ] WebSocket details (connect/message/disconnect handlers, room management)
-- [ ] GraphQL schema/resolver generation
-- [ ] gRPC service/method definitions
-- [ ] Pattern matching in IR → target language switch/match statements
-- [ ] Async/await mapping per target language
+- [x] WebSocket details (connect/message/disconnect handlers, room management)
+- [x] GraphQL schema/resolver generation
+- [x] gRPC service/method definitions
+- [x] Pattern matching in IR → target language switch/match statements
+- [x] Async/await mapping per target language
 
 ## When Polyglot Is Ready: Documentation & Website Updates
 

--- a/pkg/ir/analyzer.go
+++ b/pkg/ir/analyzer.go
@@ -957,6 +957,26 @@ func (a *Analyzer) convertExpr(expr ast.Expr) ExprIR {
 		return a.convertMatchExpr(e)
 	case ast.MatchExpr:
 		return a.convertMatchExpr(&e)
+	case *ast.AsyncExpr:
+		return ExprIR{
+			Kind:  ExprAsync,
+			Async: &AsyncExprIR{Body: a.convertStatements(e.Body)},
+		}
+	case ast.AsyncExpr:
+		return ExprIR{
+			Kind:  ExprAsync,
+			Async: &AsyncExprIR{Body: a.convertStatements(e.Body)},
+		}
+	case *ast.AwaitExpr:
+		return ExprIR{
+			Kind:  ExprAwait,
+			Await: &AwaitExprIR{Expr: a.convertExpr(e.Expr)},
+		}
+	case ast.AwaitExpr:
+		return ExprIR{
+			Kind:  ExprAwait,
+			Await: &AwaitExprIR{Expr: a.convertExpr(e.Expr)},
+		}
 	default:
 		return ExprIR{Kind: ExprNull, IsNull: true}
 	}

--- a/pkg/ir/ir.go
+++ b/pkg/ir/ir.go
@@ -427,6 +427,8 @@ type ExprIR struct {
 	Lambda      *LambdaExpr
 	Pipe        *PipeExpr
 	Match       *MatchExpr
+	Async       *AsyncExprIR
+	Await       *AwaitExprIR
 }
 
 // ExprKind classifies the type of expression.
@@ -449,6 +451,8 @@ const (
 	ExprLambda
 	ExprPipe
 	ExprMatch
+	ExprAsync
+	ExprAwait
 )
 
 // BinaryExpr describes a binary operation.
@@ -537,6 +541,16 @@ type LambdaExpr struct {
 type PipeExpr struct {
 	Left  ExprIR
 	Right ExprIR
+}
+
+// AsyncExprIR describes an async block.
+type AsyncExprIR struct {
+	Body []StmtIR
+}
+
+// AwaitExprIR describes an await expression.
+type AwaitExprIR struct {
+	Expr ExprIR
 }
 
 // MatchExpr describes a pattern match.


### PR DESCRIPTION
## Summary
- Implements all five Phase 6 items from the polyglot roadmap: WebSocket, GraphQL, gRPC, pattern matching, and async/await code generation across both Python/FastAPI and TypeScript/Express targets
- Adds `ExprAsync`/`ExprAwait` IR types and analyzer conversion for async/await support
- Fixes Makefile test targets to include integration tests (`./...` instead of `./pkg/...`)
- Marks Phase 4 CI pipeline item and all Phase 6 items complete in the roadmap

## Changes

### Pattern Matching + Pipe + Switch
- `StmtSwitch` → `if/elif/else` (Python), `switch/case` (TypeScript)
- `ExprMatch` → match expression helpers with pattern rendering
- `ExprPipe` → `right(left)` function composition in both targets

### WebSocket
- Python: `ConnectionManager` class, `@app.websocket()` decorators, connect/message/disconnect/error handlers
- TypeScript: `WebSocketServer` from `ws`, `createServer` HTTP upgrade, auto-switches to `server.listen()`

### Async/Await
- IR: `ExprAsync`, `ExprAwait` enum variants + `AsyncExprIR`, `AwaitExprIR` structs
- Analyzer: Converts `ast.AsyncExpr`/`ast.AwaitExpr` to IR
- Codegen: Native `await` in both Python and TypeScript

### GraphQL
- Python: Strawberry schema with `@strawberry.type` classes, `GraphQLRouter` mount
- TypeScript: Apollo Server with `typeDefs`/`resolvers`, `expressMiddleware` mount

### gRPC
- Python: `Servicer` classes with proto comments, handler methods, `grpcio` dependency
- TypeScript: Handler objects with `@grpc/grpc-js`, proto comments, stub methods

### Infrastructure
- Makefile: Test targets now use `./...` to include `tests/` package
- Roadmap: Phase 4 CI pipeline and Phase 6 items marked complete

## Test Plan
- [x] 22 new unit tests covering all five features in both generators
- [x] All existing tests pass (59 codegen tests, full suite across 49 packages)
- [x] `go test -race ./...` passes
- [x] `go vet ./...` clean
- [x] `gofmt -l .` clean