### PR TITLE
fix: parse request body for DELETE handlers

### DIFF
--- a/cmd/glyph/handlers.go
+++ b/cmd/glyph/handlers.go
@@ -205,9 +205,10 @@ func createRouteHandler(route *ast.Route, interp *interpreter.Interpreter) serve
 
 // executeRoute executes a route's body and returns the full interpreter response.
 func executeRoute(route *ast.Route, ctx *server.Context, interp *interpreter.Interpreter) (*interpreter.Response, error) {
-	// Parse request body for POST/PUT/PATCH requests
+	// Parse request body for POST/PUT/PATCH/DELETE requests.
+	// RFC 7231 permits DELETE to carry a body, and some APIs rely on it.
 	var requestBody interface{}
-	if ctx.Request.Method == "POST" || ctx.Request.Method == "PUT" || ctx.Request.Method == "PATCH" {
+	if ctx.Request.Method == "POST" || ctx.Request.Method == "PUT" || ctx.Request.Method == "PATCH" || ctx.Request.Method == "DELETE" {
 		// Only parse if there's a content type that suggests JSON
 		contentType := ctx.Request.Header.Get("Content-Type")
 		// Accept empty content-type or application/json

--- a/pkg/server/handler.go
+++ b/pkg/server/handler.go
@@ -44,8 +44,9 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		StatusCode:     http.StatusOK,
 	}
 
-	// Parse JSON body if present
-	if r.Method == "POST" || r.Method == "PUT" || r.Method == "PATCH" {
+	// Parse JSON body if present.
+	// RFC 7231 permits DELETE to carry a body, so parse it as well.
+	if r.Method == "POST" || r.Method == "PUT" || r.Method == "PATCH" || r.Method == "DELETE" {
 		if err := parseJSONBody(r, ctx); err != nil {
 			h.handleError(w, r, http.StatusBadRequest, "invalid JSON body", err)
 			return

--- a/pkg/server/handler_delete_test.go
+++ b/pkg/server/handler_delete_test.go
@@ -1,0 +1,97 @@
+package server
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestHandlerDELETEWithJSONBody verifies DELETE handlers parse JSON bodies.
+// RFC 7231 permits DELETE to carry a request body; see issue #239.
+func TestHandlerDELETEWithJSONBody(t *testing.T) {
+	interpreter := &MockInterpreter{}
+
+	server := NewServer(WithInterpreter(interpreter))
+	server.RegisterRoute(&Route{
+		Method: DELETE,
+		Path:   "/api/games/:rc",
+	})
+
+	requestBody := map[string]interface{}{
+		"session_token": "tok1",
+	}
+	body, err := json.Marshal(requestBody)
+	require.NoError(t, err)
+	req := httptest.NewRequest("DELETE", "/api/games/ABCD", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	server.GetHandler().ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var response map[string]interface{}
+	err = json.Unmarshal(w.Body.Bytes(), &response)
+	require.NoError(t, err)
+
+	bodyData, ok := response["body"].(map[string]interface{})
+	require.True(t, ok, "expected DELETE request body to be parsed")
+	assert.Equal(t, "tok1", bodyData["session_token"])
+}
+
+// TestHandlerDELETEWithEmptyBody verifies DELETE with no body does not error.
+func TestHandlerDELETEWithEmptyBody(t *testing.T) {
+	interpreter := &MockInterpreter{}
+
+	server := NewServer(WithInterpreter(interpreter))
+	server.RegisterRoute(&Route{
+		Method: DELETE,
+		Path:   "/api/games/:rc",
+	})
+
+	req := httptest.NewRequest("DELETE", "/api/games/ABCD", nil)
+	w := httptest.NewRecorder()
+
+	server.GetHandler().ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var response map[string]interface{}
+	err := json.Unmarshal(w.Body.Bytes(), &response)
+	require.NoError(t, err)
+	_, hasBody := response["body"]
+	assert.False(t, hasBody, "expected no body field for empty DELETE body")
+}
+
+// TestHandlerDELETENonJSONContentType verifies DELETE with a non-JSON
+// Content-Type returns 400, matching POST behavior.
+func TestHandlerDELETENonJSONContentType(t *testing.T) {
+	interpreter := &MockInterpreter{}
+
+	server := NewServer(WithInterpreter(interpreter))
+	server.RegisterRoute(&Route{
+		Method: DELETE,
+		Path:   "/api/games/:rc",
+	})
+
+	req := httptest.NewRequest("DELETE", "/api/games/ABCD", bytes.NewBufferString("some text"))
+	req.Header.Set("Content-Type", "text/plain")
+	w := httptest.NewRecorder()
+
+	server.GetHandler().ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+
+	var response map[string]interface{}
+	err := json.Unmarshal(w.Body.Bytes(), &response)
+	require.NoError(t, err)
+	errVal, ok := response["error"].(bool)
+	require.True(t, ok)
+	assert.True(t, errVal)
+	assert.Contains(t, response["message"], "invalid JSON body")
+}


### PR DESCRIPTION
## Summary
- Enable JSON body parsing for DELETE requests, matching POST/PUT/PATCH behavior.
- Fixes input being null in DELETE handlers when clients send a valid JSON body.
- Closes #239

## Changes
- cmd/glyph/handlers.go:210 — add DELETE to the method gate for body parsing.
- pkg/server/handler.go:48 — same, in the standalone server handler path.
- pkg/server/handler_delete_test.go — three tests: JSON body populates input; empty body leaves input nil; non-JSON Content-Type returns 400 consistent with POST.

## Rationale
RFC 7231 permits DELETE to carry a body. Common real-world pattern: callers send a session token or confirmation payload in the DELETE body to authorize the operation. Prior behavior forced callers to switch to POST or put credentials on the URL.

## Test Plan
- [x] go build ./...
- [x] go test -race ./...
- [x] go vet ./...
- [x] gofmt -l .
- [x] Manual curl repro from #239 now returns 200 with the parsed token