### PR TITLE
fix: expose query params to compiled routes (#240)

### DIFF
--- a/cmd/glyph/handlers.go
+++ b/cmd/glyph/handlers.go
@@ -109,6 +109,39 @@ func createCompiledRouteHandler(route *ast.Route, bytecode []byte, wsHub *websoc
 			vmInstance.SetLocal(key, vm.StringValue{Val: value})
 		}
 
+		// Inject query parameters as 'query' object (and individual declared
+		// params) so compiled routes can read query.X the same as interpreted
+		// routes. Reuses interpreter.ProcessQueryParams to guarantee parity
+		// with interpreter mode (issue #240).
+		rawQuery := map[string][]string(ctx.Request.URL.Query())
+		queryParams, qErr := interpreter.ProcessQueryParams(rawQuery, route.QueryParams)
+		if qErr != nil {
+			// Same pattern as success responses below (ctx.StatusCode +
+			// WriteHeader): ctx.StatusCode is for middleware/logging, but
+			// the actual status line needs WriteHeader to flip from 200.
+			ctx.StatusCode = http.StatusBadRequest
+			ctx.ResponseWriter.Header().Set("Content-Type", "application/json")
+			ctx.ResponseWriter.WriteHeader(http.StatusBadRequest)
+			if encErr := json.NewEncoder(ctx.ResponseWriter).Encode(map[string]interface{}{
+				"error": qErr.Error(),
+			}); encErr != nil {
+				return fmt.Errorf("failed to encode query-param error response: %w", encErr)
+			}
+			return nil
+		}
+		queryObj := make(map[string]vm.Value, len(queryParams))
+		for k, v := range queryParams {
+			queryObj[k] = interfaceToValue(v)
+		}
+		vmInstance.SetLocal("query", vm.ObjectValue{Val: queryObj})
+		// Also bind declared query params directly as variables so `q` works
+		// in addition to `query.q` (matches interpreter behavior).
+		for _, decl := range route.QueryParams {
+			if val, ok := queryParams[decl.Name]; ok {
+				vmInstance.SetLocal(decl.Name, interfaceToValue(val))
+			}
+		}
+
 		// Parse and inject request body as 'input' for POST/PUT/PATCH requests
 		if ctx.Request.Method == "POST" || ctx.Request.Method == "PUT" || ctx.Request.Method == "PATCH" {
 			contentType := ctx.Request.Header.Get("Content-Type")

--- a/cmd/glyph/handlers_query_test.go
+++ b/cmd/glyph/handlers_query_test.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/glyphlang/glyph/pkg/ast"
+	"github.com/glyphlang/glyph/pkg/compiler"
+	"github.com/glyphlang/glyph/pkg/server"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// compileFirstRoute parses GLYPH source and returns the first route and its
+// compiled bytecode. Used by tests that need to exercise the compiled route
+// handler directly.
+func compileFirstRoute(t *testing.T, source string) (*ast.Route, []byte) {
+	t.Helper()
+	module, err := parseSource(source)
+	require.NoError(t, err, "parse source")
+
+	var route *ast.Route
+	for _, item := range module.Items {
+		if r, ok := item.(*ast.Route); ok {
+			route = r
+			break
+		}
+	}
+	require.NotNil(t, route, "no route found in source")
+
+	c := compiler.NewCompiler()
+	bytecode, err := c.CompileRoute(route)
+	require.NoError(t, err, "compile route")
+	return route, bytecode
+}
+
+// invokeCompiledRoute builds a Context from an incoming rawURL and invokes
+// the compiled route handler. Returns the HTTP recorder so tests can assert
+// on status code and body.
+func invokeCompiledRoute(t *testing.T, route *ast.Route, bytecode []byte, method, rawURL string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(method, rawURL, nil)
+	rec := httptest.NewRecorder()
+	ctx := &server.Context{
+		Request:        req,
+		ResponseWriter: rec,
+		PathParams:     map[string]string{},
+		StatusCode:     http.StatusOK,
+	}
+	handler := createCompiledRouteHandler(route, bytecode, nil)
+	require.NoError(t, handler(ctx), "handler error")
+	return rec
+}
+
+// TestCompiledRouteQueryAccess verifies that a compiled-mode route with a
+// declared query parameter can read `query.X` — the bug reported in #240.
+func TestCompiledRouteQueryAccess(t *testing.T) {
+	src := `@ GET /api/search {
+  ? q: str!
+  > {ok: true, q: query.q}
+}`
+	route, bytecode := compileFirstRoute(t, src)
+	rec := invokeCompiledRoute(t, route, bytecode, "GET", "/api/search?q=hello")
+
+	assert.Equal(t, http.StatusOK, rec.Code, "body=%s", rec.Body.String())
+	var body map[string]interface{}
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&body))
+	assert.Equal(t, true, body["ok"])
+	assert.Equal(t, "hello", body["q"])
+	assert.NotContains(t, rec.Body.String(), "undefined variable: query")
+}
+
+// TestCompiledRouteQueryEmpty verifies that a route with no query param
+// declarations still has `query` defined (as an empty object) — i.e. no
+// "undefined variable: query" error even when the handler does not touch it.
+func TestCompiledRouteQueryEmpty(t *testing.T) {
+	src := `@ GET /api/ping {
+  > {ok: true}
+}`
+	route, bytecode := compileFirstRoute(t, src)
+	rec := invokeCompiledRoute(t, route, bytecode, "GET", "/api/ping")
+
+	assert.Equal(t, http.StatusOK, rec.Code, "body=%s", rec.Body.String())
+	assert.NotContains(t, rec.Body.String(), "undefined variable")
+}
+
+// TestCompiledRouteQueryTypedParam verifies that declared typed query params
+// (e.g. int) are coerced and accessible via `query.X` in compiled mode.
+func TestCompiledRouteQueryTypedParam(t *testing.T) {
+	src := `@ GET /api/items {
+  ? limit: int = 10
+  > {limit: query.limit}
+}`
+	route, bytecode := compileFirstRoute(t, src)
+	rec := invokeCompiledRoute(t, route, bytecode, "GET", "/api/items?limit=42")
+
+	assert.Equal(t, http.StatusOK, rec.Code, "body=%s", rec.Body.String())
+	var body map[string]interface{}
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&body))
+	assert.Equal(t, float64(42), body["limit"])
+}
+
+// TestCompiledRouteInvalidQueryParam verifies that a bad type in a declared
+// query param surfaces as a 400 Bad Request, matching interpreter behavior.
+func TestCompiledRouteInvalidQueryParam(t *testing.T) {
+	src := `@ GET /api/items {
+  ? limit: int = 10
+  > {limit: query.limit}
+}`
+	route, bytecode := compileFirstRoute(t, src)
+	rec := invokeCompiledRoute(t, route, bytecode, "GET", "/api/items?limit=notanumber")
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code, "body=%s", rec.Body.String())
+	assert.True(t, strings.Contains(rec.Body.String(), "limit"),
+		"error should mention the offending param, got %q", rec.Body.String())
+}


### PR DESCRIPTION
## Summary
- Compiled-mode routes threw `undefined variable: query` because the compiled route handler in `cmd/glyph/handlers.go` never populated the `query` local in the VM. The compiler registered `query` as a builtin symbol (`pkg/compiler/compiler.go:152`) but nothing injected a value at runtime.
- Closes #240

## Changes
- `cmd/glyph/handlers.go`: inject `query` as an `ObjectValue` into VM locals before executing compiled routes, and also bind each declared query param directly by name (parity with interpreter mode). Routes a `ProcessQueryParams` error as a 400 JSON response — same contract as the interpreter path.
- `cmd/glyph/handlers_query_test.go`: four regression tests covering access via `query.X`, empty-query routes, declared typed params, and invalid-type responses.

## Test Plan
- [x] `go build ./...`
- [x] `go test -race ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [x] New tests pass: `TestCompiledRouteQueryAccess`, `TestCompiledRouteQueryEmpty`, `TestCompiledRouteQueryTypedParam`, `TestCompiledRouteInvalidQueryParam`