### PR TITLE
fix: URL-decode query parameter keys and values

### DIFF
--- a/pkg/interpreter/interpreter.go
+++ b/pkg/interpreter/interpreter.go
@@ -511,7 +511,15 @@ func (i *Interpreter) ExecuteRoute(route *Route, request *Request) (*Response, e
 	}
 
 	// Extract and process query parameters with type conversion
-	rawQueryParams := ExtractRawQueryParams(request.Path)
+	rawQueryParams, err := ExtractRawQueryParams(request.Path)
+	if err != nil {
+		return &Response{
+			StatusCode: 400,
+			Body: map[string]interface{}{
+				"error": err.Error(),
+			},
+		}, err
+	}
 	queryParams, err := ProcessQueryParams(rawQueryParams, route.QueryParams)
 	if err != nil {
 		return &Response{

--- a/pkg/interpreter/query_params.go
+++ b/pkg/interpreter/query_params.go
@@ -4,6 +4,7 @@ import (
 	. "github.com/glyphlang/glyph/pkg/ast"
 
 	"fmt"
+	"net/url"
 	"strconv"
 	"strings"
 )
@@ -158,18 +159,20 @@ func convertToArray(values []string, arrayType Type) ([]interface{}, error) {
 	return result, nil
 }
 
-// ExtractRawQueryParams extracts all query parameter values from URL path
-func ExtractRawQueryParams(path string) map[string][]string {
+// ExtractRawQueryParams extracts all query parameter values from a URL path.
+// Percent-encoded sequences are decoded per RFC 3986. Returns an error if
+// any key or value contains a malformed percent sequence.
+func ExtractRawQueryParams(path string) (map[string][]string, error) {
 	result := make(map[string][]string)
 
 	idx := strings.Index(path, "?")
 	if idx == -1 {
-		return result
+		return result, nil
 	}
 
 	queryString := path[idx+1:]
 	if queryString == "" {
-		return result
+		return result, nil
 	}
 
 	pairs := strings.Split(queryString, "&")
@@ -178,13 +181,19 @@ func ExtractRawQueryParams(path string) map[string][]string {
 			continue
 		}
 		parts := strings.SplitN(pair, "=", 2)
-		key := parts[0]
+		key, err := url.QueryUnescape(parts[0])
+		if err != nil {
+			return nil, fmt.Errorf("malformed query parameter key %q: %w", parts[0], err)
+		}
 		value := ""
 		if len(parts) == 2 {
-			value = parts[1]
+			value, err = url.QueryUnescape(parts[1])
+			if err != nil {
+				return nil, fmt.Errorf("malformed query parameter value for %q: %w", key, err)
+			}
 		}
 		result[key] = append(result[key], value)
 	}
 
-	return result
+	return result, nil
 }

--- a/pkg/interpreter/query_params_test.go
+++ b/pkg/interpreter/query_params_test.go
@@ -50,14 +50,36 @@ func TestExtractRawQueryParams(t *testing.T) {
 			path:     "/api/users?debug",
 			expected: map[string][]string{"debug": {""}},
 		},
+		{
+			name:     "percent-encoded value",
+			path:     "/api/search?q=hello%20world",
+			expected: map[string][]string{"q": {"hello world"}},
+		},
+		{
+			name:     "percent-encoded key and value",
+			path:     "/api/data?user%20name=John%20Doe",
+			expected: map[string][]string{"user name": {"John Doe"}},
+		},
+		{
+			name:     "plus as space",
+			path:     "/api/search?q=hello+world",
+			expected: map[string][]string{"q": {"hello world"}},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := ExtractRawQueryParams(tt.path)
+			result, err := ExtractRawQueryParams(tt.path)
+			require.NoError(t, err)
 			assert.Equal(t, tt.expected, result)
 		})
 	}
+}
+
+func TestExtractRawQueryParams_MalformedEncoding(t *testing.T) {
+	_, err := ExtractRawQueryParams("/api/search?q=%ZZ")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "malformed")
 }
 
 func TestProcessQueryParams_NoDeclarations(t *testing.T) {


### PR DESCRIPTION
## Summary
- `ExtractRawQueryParams` never called `url.QueryUnescape`, delivering raw percent-encoded strings to route handlers
- Closes #245

## Changes
- `pkg/interpreter/query_params.go`: decode keys and values via `url.QueryUnescape`; return error on malformed encoding
- `pkg/interpreter/interpreter.go`: handle new error return from `ExtractRawQueryParams` as 400
- `pkg/interpreter/query_params_test.go`: added percent-encoding, plus-as-space, and malformed-encoding test cases

## Test Plan
- [x] `go build ./...`
- [x] `go test -race ./...` — all pass
- [x] `go vet ./...` — clean
- [x] `gofmt -l .` — clean