### PR TITLE
fix: apply query-param defaults in compiled mode

### DIFF
--- a/cmd/glyph/handlers.go
+++ b/cmd/glyph/handlers.go
@@ -129,6 +129,15 @@ func createCompiledRouteHandler(route *ast.Route, bytecode []byte, wsHub *websoc
 			}
 			return nil
 		}
+		// Apply defaults for declared params not provided in the URL,
+		// matching the interpreter path at interpreter.go:525-534.
+		for _, decl := range route.QueryParams {
+			if _, exists := queryParams[decl.Name]; !exists && decl.Default != nil {
+				if val, ok := evalLiteralExpr(decl.Default); ok {
+					queryParams[decl.Name] = val
+				}
+			}
+		}
 		queryObj := make(map[string]vm.Value, len(queryParams))
 		for k, v := range queryParams {
 			queryObj[k] = interfaceToValue(v)
@@ -665,4 +674,29 @@ func openURL(urlStr string) error {
 	}
 
 	return cmd.Start()
+}
+
+// evalLiteralExpr evaluates a constant AST expression (typically a query-param
+// default like = 1 or = "foo") and returns its Go value. Returns (nil,
+// false) for non-literal expressions; callers should skip the default in that
+// case. This keeps the compiled path free of a full interpreter dependency.
+func evalLiteralExpr(expr ast.Expr) (interface{}, bool) {
+	lit, ok := expr.(ast.LiteralExpr)
+	if !ok {
+		return nil, false
+	}
+	switch v := lit.Value.(type) {
+	case ast.IntLiteral:
+		return v.Value, true
+	case ast.FloatLiteral:
+		return v.Value, true
+	case ast.StringLiteral:
+		return v.Value, true
+	case ast.BoolLiteral:
+		return v.Value, true
+	case ast.NullLiteral:
+		return nil, true
+	default:
+		return nil, false
+	}
 }

--- a/cmd/glyph/handlers_query_test.go
+++ b/cmd/glyph/handlers_query_test.go
@@ -117,3 +117,50 @@ func TestCompiledRouteInvalidQueryParam(t *testing.T) {
 	assert.True(t, strings.Contains(rec.Body.String(), "limit"),
 		"error should mention the offending param, got %q", rec.Body.String())
 }
+
+// TestCompiledRouteQueryDefaultApplied verifies that a declared query param
+// with a default value is populated when the URL omits that param (#244).
+func TestCompiledRouteQueryDefaultApplied(t *testing.T) {
+	src := `@ GET /api/items {
+  ? limit: int = 25
+  > {limit: query.limit}
+}`
+	route, bytecode := compileFirstRoute(t, src)
+	rec := invokeCompiledRoute(t, route, bytecode, "GET", "/api/items")
+
+	assert.Equal(t, http.StatusOK, rec.Code, "body=%s", rec.Body.String())
+	var body map[string]interface{}
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&body))
+	assert.Equal(t, float64(25), body["limit"], "default should be applied when param is absent")
+}
+
+// TestCompiledRouteQueryDefaultOverridden verifies that an explicit value
+// overrides a declared default.
+func TestCompiledRouteQueryDefaultOverridden(t *testing.T) {
+	src := `@ GET /api/items {
+  ? limit: int = 25
+  > {limit: query.limit}
+}`
+	route, bytecode := compileFirstRoute(t, src)
+	rec := invokeCompiledRoute(t, route, bytecode, "GET", "/api/items?limit=5")
+
+	assert.Equal(t, http.StatusOK, rec.Code, "body=%s", rec.Body.String())
+	var body map[string]interface{}
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&body))
+	assert.Equal(t, float64(5), body["limit"], "explicit value should override default")
+}
+
+// TestCompiledRouteQueryStringDefault verifies string defaults work.
+func TestCompiledRouteQueryStringDefault(t *testing.T) {
+	src := `@ GET /api/items {
+  ? sort: str = "name"
+  > {sort: query.sort}
+}`
+	route, bytecode := compileFirstRoute(t, src)
+	rec := invokeCompiledRoute(t, route, bytecode, "GET", "/api/items")
+
+	assert.Equal(t, http.StatusOK, rec.Code, "body=%s", rec.Body.String())
+	var body map[string]interface{}
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&body))
+	assert.Equal(t, "name", body["sort"], "string default should be applied")
+}


### PR DESCRIPTION
## Summary
- Compiled routes silently dropped declared query-param defaults (`? page: int = 1`); interpreter mode applied them correctly
- Closes #244

## Changes
- `cmd/glyph/handlers.go`: add `evalLiteralExpr` helper + default-application loop before building VM query locals
- `cmd/glyph/handlers_query_test.go`: three new tests — default applied, default overridden by explicit value, string default

## Test Plan
- [x] `go build ./...`
- [x] `go test -race ./...` — all pass
- [x] `go vet ./...` — clean
- [x] `gofmt -l .` — clean
- [x] `TestCompiledRouteQueryDefaultApplied`, `TestCompiledRouteQueryDefaultOverridden`, `TestCompiledRouteQueryStringDefault`