### PR TITLE
feat: expose request headers to route handlers

### DIFF
--- a/cmd/glyph/handlers.go
+++ b/cmd/glyph/handlers.go
@@ -168,6 +168,16 @@ func createCompiledRouteHandler(route *ast.Route, bytecode []byte, wsHub *websoc
 			vmInstance.SetLocal("input", vm.NullValue{})
 		}
 
+		// Inject request headers as 'headers' object. Keys use Go's
+		// canonical format (e.g. "Content-Type"). First value only.
+		headerObj := make(map[string]vm.Value, len(ctx.Request.Header))
+		for k, vals := range ctx.Request.Header {
+			if len(vals) > 0 {
+				headerObj[k] = vm.StringValue{Val: vals[0]}
+			}
+		}
+		vmInstance.SetLocal("headers", vm.ObjectValue{Val: headerObj})
+
 		// Execute compiled bytecode
 		result, err := vmInstance.Execute(bytecode)
 		if err != nil {

--- a/cmd/glyph/handlers_query_test.go
+++ b/cmd/glyph/handlers_query_test.go
@@ -117,3 +117,29 @@ func TestCompiledRouteInvalidQueryParam(t *testing.T) {
 	assert.True(t, strings.Contains(rec.Body.String(), "limit"),
 		"error should mention the offending param, got %q", rec.Body.String())
 }
+
+// TestCompiledRouteHeadersAccess verifies that compiled routes can read
+// request headers via the built-in headers variable (issue 241).
+func TestCompiledRouteHeadersAccess(t *testing.T) {
+	src := `@ GET /api/echo {
+  > {ct: headers["Content-Type"]}
+}`
+	route, bytecode := compileFirstRoute(t, src)
+
+	req := httptest.NewRequest("GET", "/api/echo", nil)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	ctx := &server.Context{
+		Request:        req,
+		ResponseWriter: rec,
+		PathParams:     map[string]string{},
+		StatusCode:     http.StatusOK,
+	}
+	handler := createCompiledRouteHandler(route, bytecode, nil)
+	require.NoError(t, handler(ctx), "handler error")
+
+	assert.Equal(t, http.StatusOK, rec.Code, "body=%s", rec.Body.String())
+	var body map[string]interface{}
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&body))
+	assert.Equal(t, "application/json", body["ct"])
+}

--- a/pkg/compiler/compiler.go
+++ b/pkg/compiler/compiler.go
@@ -151,6 +151,10 @@ func (c *Compiler) CompileRoute(route *ast.Route) ([]byte, error) {
 	queryIdx := c.addConstant(vm.StringValue{Val: "query"})
 	c.symbolTable.DefineBuiltin("query", queryIdx)
 
+	// headers - HTTP request headers (always available)
+	headersIdx := c.addConstant(vm.StringValue{Val: "headers"})
+	c.symbolTable.DefineBuiltin("headers", headersIdx)
+
 	// input - Request body (always available, may be nil)
 	inputIdx := c.addConstant(vm.StringValue{Val: "input"})
 	c.symbolTable.DefineBuiltin("input", inputIdx)

--- a/pkg/interpreter/headers_test.go
+++ b/pkg/interpreter/headers_test.go
@@ -1,0 +1,88 @@
+package interpreter
+
+import (
+	"testing"
+
+	. "github.com/glyphlang/glyph/pkg/ast"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestInterpreter_HeadersAccessible verifies that route handlers can read
+// request headers via the 'headers' built-in variable (#241).
+func TestInterpreter_HeadersAccessible(t *testing.T) {
+	interp := NewInterpreter()
+
+	route := &Route{
+		Path:   "/api/echo",
+		Method: Get,
+		Body: []Statement{
+			ReturnStatement{
+				Value: ObjectExpr{
+					Fields: []ObjectField{
+						{Key: "auth", Value: FieldAccessExpr{
+							Object: VariableExpr{Name: "headers"},
+							Field:  "Authorization",
+						}},
+					},
+				},
+			},
+		},
+	}
+
+	request := &Request{
+		Path:   "/api/echo",
+		Method: "GET",
+		Headers: map[string]string{
+			"Authorization": "Bearer tok123",
+			"Content-Type":  "application/json",
+		},
+	}
+
+	response, err := interp.ExecuteRoute(route, request)
+	require.NoError(t, err)
+	require.NotNil(t, response)
+	assert.Equal(t, 200, response.StatusCode)
+
+	body, ok := response.Body.(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "Bearer tok123", body["auth"])
+}
+
+// TestInterpreter_HeadersMissing verifies that accessing an absent header
+// returns nil rather than an error.
+func TestInterpreter_HeadersMissing(t *testing.T) {
+	interp := NewInterpreter()
+
+	route := &Route{
+		Path:   "/api/echo",
+		Method: Get,
+		Body: []Statement{
+			ReturnStatement{
+				Value: ObjectExpr{
+					Fields: []ObjectField{
+						{Key: "val", Value: FieldAccessExpr{
+							Object: VariableExpr{Name: "headers"},
+							Field:  "X-Missing",
+						}},
+					},
+				},
+			},
+		},
+	}
+
+	request := &Request{
+		Path:    "/api/echo",
+		Method:  "GET",
+		Headers: map[string]string{},
+	}
+
+	response, err := interp.ExecuteRoute(route, request)
+	require.NoError(t, err)
+	require.NotNil(t, response)
+	assert.Equal(t, 200, response.StatusCode)
+
+	body, ok := response.Body.(map[string]interface{})
+	require.True(t, ok)
+	assert.Nil(t, body["val"])
+}

--- a/pkg/interpreter/interpreter.go
+++ b/pkg/interpreter/interpreter.go
@@ -583,6 +583,15 @@ func (i *Interpreter) ExecuteRoute(route *Route, request *Request) (*Response, e
 		routeEnv.Define("input", nil)
 	}
 
+	// Bind request headers as 'headers' object so route handlers can
+	// read them via headers["Content-Type"] or headers.Authorization.
+	// Keys use Go's canonical format (e.g. "Content-Type").
+	headersMap := make(map[string]interface{}, len(request.Headers))
+	for k, v := range request.Headers {
+		headersMap[k] = v
+	}
+	routeEnv.Define("headers", headersMap)
+
 	// Handle dependency injections
 	for _, injection := range route.Injections {
 		i.injectDependency(injection, routeEnv)

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -876,21 +876,29 @@ func (vm *VM) execGetIndex() error {
 		return err
 	}
 
-	arrVal, ok := arr.(ArrayValue)
-	if !ok {
-		return fmt.Errorf("type error: can only index arrays, got %s", arr.Type())
+	switch container := arr.(type) {
+	case ArrayValue:
+		indexInt, ok := index.(IntValue)
+		if !ok {
+			return fmt.Errorf("type error: array index must be an integer, got %s", index.Type())
+		}
+		if indexInt.Val < 0 || indexInt.Val >= int64(len(container.Val)) {
+			return fmt.Errorf("index out of bounds: %d", indexInt.Val)
+		}
+		vm.Push(container.Val[indexInt.Val])
+	case ObjectValue:
+		keyStr, ok := index.(StringValue)
+		if !ok {
+			return fmt.Errorf("type error: object key must be a string, got %s", index.Type())
+		}
+		if val, exists := container.Val[keyStr.Val]; exists {
+			vm.Push(val)
+		} else {
+			vm.Push(NullValue{})
+		}
+	default:
+		return fmt.Errorf("type error: can only index arrays or objects, got %s", arr.Type())
 	}
-
-	indexInt, ok := index.(IntValue)
-	if !ok {
-		return fmt.Errorf("type error: array index must be an integer, got %s", index.Type())
-	}
-
-	if indexInt.Val < 0 || indexInt.Val >= int64(len(arrVal.Val)) {
-		return fmt.Errorf("index out of bounds: %d", indexInt.Val)
-	}
-
-	vm.Push(arrVal.Val[indexInt.Val])
 	return nil
 }
 


### PR DESCRIPTION
## Summary
- Route handlers can now access request headers via a `headers` built-in variable in both interpreter and compiled modes.
- Closes #241

## Changes
- `pkg/interpreter/interpreter.go`: Bind `headers` in the route environment as a `map[string]interface{}` built from `request.Headers`, alongside the existing `input`/`query` bindings.
- `pkg/compiler/compiler.go`: Register `headers` as a built-in symbol so compiled bytecode can resolve the name.
- `cmd/glyph/handlers.go`: Inject a `headers` ObjectValue (Go-canonical key → first header value as StringValue) into the VM's locals before executing compiled bytecode.
- `pkg/vm/vm.go`: Extend `execGetIndex` so `OpIndex` also works against `ObjectValue` (not just `ArrayValue`). This is required for `headers["Content-Type"]` (dot access doesn't work with hyphens) and is a general VM improvement for map access.
- Tests: `pkg/interpreter/headers_test.go` (interpreter path) and `TestCompiledRouteHeadersAccess` in `cmd/glyph/handlers_query_test.go` (compiled path).

## Usage
```glyph
@ GET /api/echo {
  > {ct: headers["Content-Type"]}
}
```
Header keys use Go's canonical HTTP header format (e.g. `Content-Type`, `Authorization`). Use bracket indexing for hyphenated names.

## Test Plan
- `go build ./...`
- `go test -race ./...` — full suite passes including new header tests
- `go vet ./...`
- `gofmt -l .`