### PR TITLE
fix: TS codegen emits unknown not any; add glyph fmt canonical formatter

### DIFF
--- a/cmd/glyph/commands_codegen.go
+++ b/cmd/glyph/commands_codegen.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"strings"
 	"sync"
 	"syscall"
 	"time"
@@ -198,6 +199,84 @@ func compactDirectory(dirPath, outputDir string) error {
 
 		return compactFile(path, outPath)
 	})
+}
+
+// runFmt handles the fmt command - canonicalizes .glyph file formatting in place
+func runFmt(cmd *cobra.Command, args []string) error {
+	filePath := args[0]
+	check, _ := cmd.Flags().GetBool("check")
+
+	absPath, err := filepath.Abs(filePath)
+	if err != nil {
+		return fmt.Errorf("failed to get absolute path: %w", err)
+	}
+
+	info, err := os.Stat(absPath)
+	if err != nil {
+		return fmt.Errorf("failed to access path: %w", err)
+	}
+
+	var unformatted []string
+	if info.IsDir() {
+		err = filepath.Walk(absPath, func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+			if info.IsDir() || filepath.Ext(path) != ".glyph" {
+				return nil
+			}
+			changed, err := fmtFile(path, check)
+			if err != nil {
+				return err
+			}
+			if changed {
+				unformatted = append(unformatted, path)
+			}
+			return nil
+		})
+		if err != nil {
+			return err
+		}
+	} else {
+		changed, err := fmtFile(absPath, check)
+		if err != nil {
+			return err
+		}
+		if changed {
+			unformatted = append(unformatted, absPath)
+		}
+	}
+
+	if check && len(unformatted) > 0 {
+		return fmt.Errorf("files not formatted: %s", strings.Join(unformatted, ", "))
+	}
+	return nil
+}
+
+// fmtFile canonicalizes a single .glyph file. In check mode it only reports
+// whether the file would change; otherwise it rewrites the file in place.
+// Already-canonical files are never rewritten, so mtimes stay stable.
+func fmtFile(path string, check bool) (bool, error) {
+	source, err := os.ReadFile(path)
+	if err != nil {
+		return false, fmt.Errorf("failed to read file: %w", err)
+	}
+
+	formatted := formatter.CanonicalizeSource(string(source))
+	if formatted == string(source) {
+		return false, nil
+	}
+
+	if check {
+		printWarning(fmt.Sprintf("%s is not formatted", path))
+		return true, nil
+	}
+
+	if err := os.WriteFile(path, []byte(formatted), 0600); err != nil {
+		return false, fmt.Errorf("failed to write file: %w", err)
+	}
+	printSuccess(fmt.Sprintf("Formatted %s", path))
+	return true, nil
 }
 
 // runOpenAPI handles the openapi command

--- a/cmd/glyph/main.go
+++ b/cmd/glyph/main.go
@@ -413,6 +413,32 @@ Examples:
 	irCmd.Flags().StringP("output", "o", "", "Output file (default: stdout)")
 	irCmd.Flags().Bool("pretty", true, "Pretty-print JSON output")
 
+	// Fmt command - canonical zero-option formatter
+	var fmtCmd = &cobra.Command{
+		Use:   "fmt <file|dir>",
+		Short: "Format .glyph files with the canonical zero-option style",
+		Long: `Fmt rewrites .glyph files in place using the canonical GlyphLang style.
+It is zero-option by design: there is exactly one valid formatting.
+
+Content within a line is never reflowed, so a one-line change stays a
+one-line diff. Comments and strings are preserved byte-for-byte.
+
+Canonical rules:
+  1. Line endings normalized to LF
+  2. Trailing whitespace stripped
+  3. Indentation is 2 spaces per bracket depth
+  4. At most one consecutive blank line, none at file start
+  5. Exactly one trailing newline
+
+Examples:
+  glyph fmt main.glyph          # Format a single file in place
+  glyph fmt ./src               # Format all .glyph files in a directory
+  glyph fmt ./src --check       # Exit 1 if any file is not formatted (CI)`,
+		Args: cobra.ExactArgs(1),
+		RunE: runFmt,
+	}
+	fmtCmd.Flags().Bool("check", false, "Do not write; exit non-zero if files are not formatted")
+
 	rootCmd.AddCommand(compileCmd)
 	rootCmd.AddCommand(decompileCmd)
 	rootCmd.AddCommand(runCmd)
@@ -425,6 +451,7 @@ Examples:
 	rootCmd.AddCommand(validateCmd)
 	rootCmd.AddCommand(expandCmd)
 	rootCmd.AddCommand(compactCmd)
+	rootCmd.AddCommand(fmtCmd)
 	rootCmd.AddCommand(replCmd)
 	rootCmd.AddCommand(openapiCmd)
 	rootCmd.AddCommand(docsCmd)

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -176,6 +176,30 @@ INSTRUCTIONS:
 $ glyph decompile --disasm build/hello.glyphc
 ```
 
+### `glyph fmt <file|dir>`
+
+Format .glyph files with the canonical zero-option style. There is exactly one valid formatting, so there is nothing to configure.
+
+```bash
+glyph fmt main.glyph          # Format a single file in place
+glyph fmt ./src               # Format all .glyph files in a directory
+glyph fmt ./src --check       # Exit 1 if any file is not formatted (CI)
+
+# Options:
+#   --check   Do not write; exit non-zero if files are not formatted
+```
+
+**Canonical rules:**
+1. Line endings normalized to LF
+2. Trailing whitespace stripped
+3. Indentation is 2 spaces per bracket depth
+4. At most one consecutive blank line, none at file start
+5. Exactly one trailing newline
+
+Content within a line is never reflowed, so a one-line change stays a one-line diff. Comments and strings are preserved byte-for-byte. Already-canonical files are not rewritten, keeping modification times stable.
+
+**CI usage:** run `glyph fmt . --check` in your pipeline to reject unformatted code.
+
 ### `glyph exec <file> <command> [args...]`
 
 Execute a CLI command defined in a Glyph source file.
@@ -451,6 +475,7 @@ Available Commands:
   context     Generate AI-optimized project context
   decompile   Decompile bytecode to readable format
   dev         Start development server with hot reload
+  fmt         Format .glyph files with the canonical zero-option style
   init        Initialize new project
   run         Run Glyph source file or bytecode
   exec        Execute a CLI command from a Glyph file

--- a/examples/auth-demo/main.glyph
+++ b/examples/auth-demo/main.glyph
@@ -135,10 +135,10 @@
 
             # Generate JWT token
             $ token = jwt.sign({
-              user_id: saved.id,
-              username: saved.username,
-              role: saved.role
-            }, "7d")
+                user_id: saved.id,
+                username: saved.username,
+                role: saved.role
+              }, "7d")
 
             # Remove password from response
             $ userResponse = {
@@ -209,10 +209,10 @@
 
           # Generate JWT token
           $ token = jwt.sign({
-            user_id: user.id,
-            username: user.username,
-            role: user.role
-          }, "7d")
+              user_id: user.id,
+              username: user.username,
+              role: user.role
+            }, "7d")
 
           # Remove password from response
           $ userResponse = {
@@ -389,10 +389,10 @@
 
   # Generate new token
   $ newToken = jwt.sign({
-    user_id: userId,
-    username: username,
-    role: role
-  }, "7d")
+      user_id: userId,
+      username: username,
+      role: role
+    }, "7d")
 
   $ expiresAt = now() + (7 * 24 * 60 * 60)
 

--- a/examples/collections-demo/main.glyph
+++ b/examples/collections-demo/main.glyph
@@ -311,12 +311,12 @@
       if product != null && product.active == true {
         $ subtotal = product.price * item.quantity
         $ enrichedItems = enrichedItems + [{
-          product_id: product.id,
-          product_name: product.name,
-          quantity: item.quantity,
-          unit_price: product.price,
-          subtotal: subtotal,
-          in_stock: product.inventory >= item.quantity
+            product_id: product.id,
+            product_name: product.name,
+            quantity: item.quantity,
+            unit_price: product.price,
+            subtotal: subtotal,
+            in_stock: product.inventory >= item.quantity
         }]
         $ total = total + subtotal
         $ itemCount = itemCount + item.quantity
@@ -388,10 +388,10 @@
 
           if cart == null {
             $ cart = db.carts.create({
-              user_id: userId,
-              items: [],
-              created_at: now(),
-              updated_at: now()
+                user_id: userId,
+                items: [],
+                created_at: now(),
+                updated_at: now()
             })
           }
 
@@ -416,8 +416,8 @@
                   $ newQuantity = product.inventory
                 }
                 $ newItems = newItems + [{
-                  product_id: item.product_id,
-                  quantity: newQuantity
+                    product_id: item.product_id,
+                    quantity: newQuantity
                 }]
               } else {
                 $ newItems = newItems + [item]
@@ -428,8 +428,8 @@
           } else {
             # Add new item
             $ cart.items = cart.items + [{
-              product_id: input.product_id,
-              quantity: quantity
+                product_id: input.product_id,
+                quantity: quantity
             }]
           }
 

--- a/examples/error-handling-demo/main.glyph
+++ b/examples/error-handling-demo/main.glyph
@@ -197,10 +197,10 @@
               $ itemTotal = product.price * item.quantity
               $ total = total + itemTotal
               $ validatedItems = validatedItems + [{
-                product_id: product.id,
-                name: product.name,
-                quantity: item.quantity,
-                price: product.price
+                  product_id: product.id,
+                  name: product.name,
+                  quantity: item.quantity,
+                  price: product.price
               }]
             }
           }
@@ -223,11 +223,11 @@
     } else {
       # Create the order
       $ newOrder = db.orders.create({
-        user_id: userId,
-        items: validatedItems,
-        total: total,
-        status: "pending",
-        created_at: now()
+          user_id: userId,
+          items: validatedItems,
+          total: total,
+          status: "pending",
+          created_at: now()
       })
 
       # Update inventory for each item
@@ -414,12 +414,12 @@
             } else {
               # Process payment (simulated)
               $ payment = db.payments.create({
-                order_id: order.id,
-                user_id: userId,
-                amount: order.total,
-                method: input.payment_method,
-                status: "completed",
-                processed_at: now()
+                  order_id: order.id,
+                  user_id: userId,
+                  amount: order.total,
+                  method: input.payment_method,
+                  status: "completed",
+                  processed_at: now()
               })
 
               # Update order status
@@ -473,8 +473,8 @@
       if update.id == null {
         $ failureCount = failureCount + 1
         $ failures = failures + [{
-          id: null,
-          error: "Product ID is required"
+            id: null,
+            error: "Product ID is required"
         }]
       } else {
         $ product = db.products.get(update.id)
@@ -482,8 +482,8 @@
         if product == null {
           $ failureCount = failureCount + 1
           $ failures = failures + [{
-            id: update.id,
-            error: "Product not found"
+              id: update.id,
+              error: "Product not found"
           }]
         } else {
           # Update product fields
@@ -631,12 +631,12 @@
           } else {
             # Create refund request
             $ refund = db.refunds.create({
-              order_id: order.id,
-              user_id: userId,
-              amount: order.total,
-              reason: input.reason,
-              status: "pending",
-              created_at: now()
+                order_id: order.id,
+                user_id: userId,
+                amount: order.total,
+                reason: input.reason,
+                status: "pending",
+                created_at: now()
             })
 
             # Update order status

--- a/examples/feature-showcase/main.glyph
+++ b/examples/feature-showcase/main.glyph
@@ -157,12 +157,12 @@ type ChatMessage {
     } else {
       # Create the user
       $ new_user = db.users.create({
-        username: username,
-        email: email,
-        role: "user",
-        age: input.age,
-        active: true,
-        created_at: now()
+          username: username,
+          email: email,
+          role: "user",
+          age: input.age,
+          active: true,
+          created_at: now()
       })
 
       > {success: true, message: "User created", data: new_user}
@@ -210,11 +210,11 @@ type ChatMessage {
     > {success: false, message: "User not found"}
   } else {
     $ updated = db.users.update(id, {
-      username: input.username,
-      email: input.email,
-      role: input.role,
-      age: input.age,
-      active: input.active
+        username: input.username,
+        email: input.email,
+        role: input.role,
+        age: input.age,
+        active: input.active
     })
 
     > {success: true, message: "User updated", data: updated}
@@ -720,11 +720,11 @@ type ChatMessage {
   switch operation {
     case "create" {
       $ new_record = db.users.create({
-        username: input.data.username,
-        email: input.data.email,
-        role: "user",
-        active: true,
-        created_at: now()
+          username: input.data.username,
+          email: input.data.email,
+          role: "user",
+          active: true,
+          created_at: now()
       })
       > {success: true, message: "Created", data: new_record}
     }
@@ -753,8 +753,8 @@ type ChatMessage {
 @ ws /chat {
   on connect {
     ws.send({
-      type: "system",
-      message: "Welcome to the chat!"
+        type: "system",
+        message: "Welcome to the chat!"
     })
   }
 
@@ -764,43 +764,43 @@ type ChatMessage {
     if data.type == "join_room" {
       ws.join(data.room)
       ws.send({
-        type: "system",
-        message: "You joined room: " + data.room
+          type: "system",
+          message: "You joined room: " + data.room
       })
       ws.broadcast_to_room(data.room, {
-        type: "system",
-        message: data.username + " joined the room"
+          type: "system",
+          message: data.username + " joined the room"
       })
     }
     else if data.type == "leave_room" {
       ws.broadcast_to_room(data.room, {
-        type: "system",
-        message: data.username + " left the room"
+          type: "system",
+          message: data.username + " left the room"
       })
       ws.leave(data.room)
     }
     else if data.type == "chat_message" {
       if data.room != "" {
         ws.broadcast_to_room(data.room, {
-          type: "chat",
-          username: data.username,
-          text: data.text,
-          room: data.room,
-          timestamp: now()
+            type: "chat",
+            username: data.username,
+            text: data.text,
+            room: data.room,
+            timestamp: now()
         })
       } else {
         ws.broadcast({
-          type: "chat",
-          username: data.username,
-          text: data.text,
-          timestamp: now()
+            type: "chat",
+            username: data.username,
+            text: data.text,
+            timestamp: now()
         })
       }
     }
     else if data.type == "ping" {
       ws.send({
-        type: "pong",
-        timestamp: now()
+          type: "pong",
+          timestamp: now()
       })
     }
   }
@@ -1069,18 +1069,18 @@ type ChatMessage {
     } else {
       # Create the order
       $ order = db.orders.create({
-        user_id: auth.user.id,
-        cart_id: cart_id,
-        items: cart.items,
-        subtotal: subtotal,
-        tax: tax,
-        shipping: shipping,
-        discount: discount,
-        total: total,
-        status: "pending",
-        payment_method: payment_method,
-        shipping_address: shipping_address,
-        created_at: now()
+          user_id: auth.user.id,
+          cart_id: cart_id,
+          items: cart.items,
+          subtotal: subtotal,
+          tax: tax,
+          shipping: shipping,
+          discount: discount,
+          total: total,
+          status: "pending",
+          payment_method: payment_method,
+          shipping_address: shipping_address,
+          created_at: now()
       })
 
       # Clear the cart

--- a/examples/intent-tests/02-webhook-processor.glyph
+++ b/examples/intent-tests/02-webhook-processor.glyph
@@ -21,9 +21,9 @@
   # Log the incoming webhook
   $ event_id = generateId()
   db.webhook_logs.Create({
-    id: event_id,
-    event: input.event,
-    received_at: now()
+      id: event_id,
+      event: input.event,
+      received_at: now()
   })
 
   # Route by event type
@@ -49,10 +49,10 @@
 
   $ event_id = generateId()
   db.webhook_logs.Create({
-    id: event_id,
-    source: "github",
-    event: input.event,
-    received_at: now()
+      id: event_id,
+      source: "github",
+      event: input.event,
+      received_at: now()
   })
 
   > {processed: true, event_id: event_id}

--- a/examples/intent-tests/03-chat-server.glyph
+++ b/examples/intent-tests/03-chat-server.glyph
@@ -25,10 +25,10 @@
   < input: CreateRoomInput
   % db: Database
   $ room = db.rooms.Create({
-    id: generateId(),
-    name: input.name,
-    created_by: auth.user.id,
-    created_at: now()
+      id: generateId(),
+      name: input.name,
+      created_by: auth.user.id,
+      created_at: now()
   })
   > room
 }

--- a/examples/intent-tests/04-job-queue.glyph
+++ b/examples/intent-tests/04-job-queue.glyph
@@ -66,13 +66,13 @@
   % db: Database
   $ job_id = generateId()
   $ created = db.email_queue.Create({
-    id: job_id,
-    to: input.to,
-    subject: input.subject,
-    template: input.template,
-    data: input.data,
-    status: "pending",
-    created_at: now()
+      id: job_id,
+      to: input.to,
+      subject: input.subject,
+      template: input.template,
+      data: input.data,
+      status: "pending",
+      created_at: now()
   })
   > {job_id: job_id, status: "pending"}
 }

--- a/examples/intent-tests/05-auth-service.glyph
+++ b/examples/intent-tests/05-auth-service.glyph
@@ -50,20 +50,20 @@
     $ hashedPassword = crypto.hash(input.password)
 
     $ user = db.users.Create({
-      id: generateId(),
-      email: input.email,
-      name: input.name,
-      password_hash: hashedPassword,
-      role: "user",
-      created_at: now()
+        id: generateId(),
+        email: input.email,
+        name: input.name,
+        password_hash: hashedPassword,
+        role: "user",
+        created_at: now()
     })
 
     # jwt.sign maps to proper JWT library in target language
     $ token = jwt.sign({
-      user_id: user.id,
-      email: user.email,
-      role: user.role
-    }, "7d")
+        user_id: user.id,
+        email: user.email,
+        role: user.role
+      }, "7d")
 
     > {
       token: token,
@@ -94,10 +94,10 @@
       $ updated = db.users.Update(user.id, {last_login: now()})
 
       $ token = jwt.sign({
-        user_id: user.id,
-        email: user.email,
-        role: user.role
-      }, "7d")
+          user_id: user.id,
+          email: user.email,
+          role: user.role
+        }, "7d")
 
       > {
         token: token,
@@ -122,9 +122,9 @@
     $ first_session = sessions[0]
 
     $ token = jwt.sign({
-      user_id: auth.user.id,
-      role: auth.user.role
-    }, "7d")
+        user_id: auth.user.id,
+        role: auth.user.role
+      }, "7d")
 
     > {
       token: token,

--- a/examples/modules-demo/main.glyph
+++ b/examples/modules-demo/main.glyph
@@ -48,11 +48,11 @@ from "./utils" import { formatDisplayName, isAdult }
   }
 
   $ newUser = db.users.create({
-    email: input.email,
-    firstName: input.firstName,
-    lastName: input.lastName,
-    age: input.age,
-    role: "user"
+      email: input.email,
+      firstName: input.firstName,
+      lastName: input.lastName,
+      age: input.age,
+      role: "user"
   })
 
   > newUser

--- a/examples/validation-demo/main.glyph
+++ b/examples/validation-demo/main.glyph
@@ -50,25 +50,25 @@
   # Validate username - required, length between 3-50 chars
   if input.username == null || input.username == "" {
     $ errors = errors + [{
-      field: "username",
-      message: "Username is required",
-      code: "REQUIRED"
+        field: "username",
+        message: "Username is required",
+        code: "REQUIRED"
     }]
     $ hasErrors = true
   } else {
     if input.username.length() < 3 {
       $ errors = errors + [{
-        field: "username",
-        message: "Username must be at least 3 characters",
-        code: "MIN_LENGTH"
+          field: "username",
+          message: "Username must be at least 3 characters",
+          code: "MIN_LENGTH"
       }]
       $ hasErrors = true
     } else {
       if input.username.length() > 50 {
         $ errors = errors + [{
-          field: "username",
-          message: "Username must be at most 50 characters",
-          code: "MAX_LENGTH"
+            field: "username",
+            message: "Username must be at most 50 characters",
+            code: "MAX_LENGTH"
         }]
         $ hasErrors = true
       }
@@ -78,9 +78,9 @@
   # Validate email - required, valid format, unique
   if input.email == null || input.email == "" {
     $ errors = errors + [{
-      field: "email",
-      message: "Email is required",
-      code: "REQUIRED"
+        field: "email",
+        message: "Email is required",
+        code: "REQUIRED"
     }]
     $ hasErrors = true
   } else {
@@ -88,9 +88,9 @@
     $ emailValid = input.email.contains("@")
     if emailValid == false {
       $ errors = errors + [{
-        field: "email",
-        message: "Invalid email format",
-        code: "INVALID_FORMAT"
+          field: "email",
+          message: "Invalid email format",
+          code: "INVALID_FORMAT"
       }]
       $ hasErrors = true
     } else {
@@ -98,9 +98,9 @@
       $ existingEmail = db.users.findOne("email", input.email)
       if existingEmail != null {
         $ errors = errors + [{
-          field: "email",
-          message: "Email already registered",
-          code: "ALREADY_EXISTS"
+            field: "email",
+            message: "Email already registered",
+            code: "ALREADY_EXISTS"
         }]
         $ hasErrors = true
       }
@@ -110,17 +110,17 @@
   # Validate password - required, minimum 8 chars
   if input.password == null || input.password == "" {
     $ errors = errors + [{
-      field: "password",
-      message: "Password is required",
-      code: "REQUIRED"
+        field: "password",
+        message: "Password is required",
+        code: "REQUIRED"
     }]
     $ hasErrors = true
   } else {
     if input.password.length() < 8 {
       $ errors = errors + [{
-        field: "password",
-        message: "Password must be at least 8 characters",
-        code: "MIN_LENGTH"
+          field: "password",
+          message: "Password must be at least 8 characters",
+          code: "MIN_LENGTH"
       }]
       $ hasErrors = true
     }
@@ -130,17 +130,17 @@
   if input.age != null {
     if input.age < 0 {
       $ errors = errors + [{
-        field: "age",
-        message: "Age cannot be negative",
-        code: "MIN_VALUE"
+          field: "age",
+          message: "Age cannot be negative",
+          code: "MIN_VALUE"
       }]
       $ hasErrors = true
     } else {
       if input.age > 150 {
         $ errors = errors + [{
-          field: "age",
-          message: "Age cannot exceed 150",
-          code: "MAX_VALUE"
+            field: "age",
+            message: "Age cannot exceed 150",
+            code: "MAX_VALUE"
         }]
         $ hasErrors = true
       }
@@ -151,9 +151,9 @@
   if input.phone != null && input.phone != "" {
     if input.phone.length() < 10 || input.phone.length() > 15 {
       $ errors = errors + [{
-        field: "phone",
-        message: "Phone must be 10-15 digits",
-        code: "INVALID_FORMAT"
+          field: "phone",
+          message: "Phone must be 10-15 digits",
+          code: "INVALID_FORMAT"
       }]
       $ hasErrors = true
     }
@@ -171,12 +171,12 @@
     # Create user
     $ hashedPassword = crypto.hash(input.password)
     $ newUser = db.users.create({
-      username: input.username,
-      email: input.email,
-      password: hashedPassword,
-      age: input.age,
-      phone: input.phone,
-      created_at: now()
+        username: input.username,
+        email: input.email,
+        password: hashedPassword,
+        age: input.age,
+        phone: input.phone,
+        created_at: now()
     })
 
     > {
@@ -209,9 +209,9 @@
       message: "User not found",
       data: null,
       errors: [{
-        field: "id",
-        message: "User with this ID does not exist",
-        code: "NOT_FOUND"
+          field: "id",
+          message: "User with this ID does not exist",
+          code: "NOT_FOUND"
       }]
     }
   } else {
@@ -220,9 +220,9 @@
       $ emailValid = input.email.contains("@")
       if emailValid == false {
         $ errors = errors + [{
-          field: "email",
-          message: "Invalid email format",
-          code: "INVALID_FORMAT"
+            field: "email",
+            message: "Invalid email format",
+            code: "INVALID_FORMAT"
         }]
         $ hasErrors = true
       } else {
@@ -230,9 +230,9 @@
         $ existingEmail = db.users.findOne("email", input.email)
         if existingEmail != null && existingEmail.id != id {
           $ errors = errors + [{
-            field: "email",
-            message: "Email already registered to another user",
-            code: "ALREADY_EXISTS"
+              field: "email",
+              message: "Email already registered to another user",
+              code: "ALREADY_EXISTS"
           }]
           $ hasErrors = true
         }
@@ -243,9 +243,9 @@
     if input.age != null {
       if input.age < 0 || input.age > 150 {
         $ errors = errors + [{
-          field: "age",
-          message: "Age must be between 0 and 150",
-          code: "OUT_OF_RANGE"
+            field: "age",
+            message: "Age must be between 0 and 150",
+            code: "OUT_OF_RANGE"
         }]
         $ hasErrors = true
       }
@@ -255,9 +255,9 @@
     if input.phone != null && input.phone != "" {
       if input.phone.length() < 10 || input.phone.length() > 15 {
         $ errors = errors + [{
-          field: "phone",
-          message: "Phone must be 10-15 digits",
-          code: "INVALID_FORMAT"
+            field: "phone",
+            message: "Phone must be 10-15 digits",
+            code: "INVALID_FORMAT"
         }]
         $ hasErrors = true
       }
@@ -266,9 +266,9 @@
     # Validate bio length if provided
     if input.bio != null && input.bio.length() > 500 {
       $ errors = errors + [{
-        field: "bio",
-        message: "Bio cannot exceed 500 characters",
-        code: "MAX_LENGTH"
+          field: "bio",
+          message: "Bio cannot exceed 500 characters",
+          code: "MAX_LENGTH"
       }]
       $ hasErrors = true
     }
@@ -319,17 +319,17 @@
   # Validate name - required, 2-100 chars
   if input.name == null || input.name == "" {
     $ errors = errors + [{
-      field: "name",
-      message: "Product name is required",
-      code: "REQUIRED"
+        field: "name",
+        message: "Product name is required",
+        code: "REQUIRED"
     }]
     $ hasErrors = true
   } else {
     if input.name.length() < 2 || input.name.length() > 100 {
       $ errors = errors + [{
-        field: "name",
-        message: "Product name must be 2-100 characters",
-        code: "LENGTH_ERROR"
+          field: "name",
+          message: "Product name must be 2-100 characters",
+          code: "LENGTH_ERROR"
       }]
       $ hasErrors = true
     }
@@ -338,25 +338,25 @@
   # Validate price - required, must be positive
   if input.price == null {
     $ errors = errors + [{
-      field: "price",
-      message: "Price is required",
-      code: "REQUIRED"
+        field: "price",
+        message: "Price is required",
+        code: "REQUIRED"
     }]
     $ hasErrors = true
   } else {
     if input.price <= 0 {
       $ errors = errors + [{
-        field: "price",
-        message: "Price must be greater than 0",
-        code: "MIN_VALUE"
+          field: "price",
+          message: "Price must be greater than 0",
+          code: "MIN_VALUE"
       }]
       $ hasErrors = true
     } else {
       if input.price > 999999.99 {
         $ errors = errors + [{
-          field: "price",
-          message: "Price cannot exceed 999999.99",
-          code: "MAX_VALUE"
+            field: "price",
+            message: "Price cannot exceed 999999.99",
+            code: "MAX_VALUE"
         }]
         $ hasErrors = true
       }
@@ -366,17 +366,17 @@
   # Validate quantity - required, non-negative integer
   if input.quantity == null {
     $ errors = errors + [{
-      field: "quantity",
-      message: "Quantity is required",
-      code: "REQUIRED"
+        field: "quantity",
+        message: "Quantity is required",
+        code: "REQUIRED"
     }]
     $ hasErrors = true
   } else {
     if input.quantity < 0 {
       $ errors = errors + [{
-        field: "quantity",
-        message: "Quantity cannot be negative",
-        code: "MIN_VALUE"
+          field: "quantity",
+          message: "Quantity cannot be negative",
+          code: "MIN_VALUE"
       }]
       $ hasErrors = true
     }
@@ -387,9 +387,9 @@
 
   if input.category == null || input.category == "" {
     $ errors = errors + [{
-      field: "category",
-      message: "Category is required",
-      code: "REQUIRED"
+        field: "category",
+        message: "Category is required",
+        code: "REQUIRED"
     }]
     $ hasErrors = true
   } else {
@@ -399,9 +399,9 @@
 
     if categoryValid == false {
       $ errors = errors + [{
-        field: "category",
-        message: "Invalid category. Must be: electronics, clothing, food, home, or other",
-        code: "INVALID_VALUE"
+          field: "category",
+          message: "Invalid category. Must be: electronics, clothing, food, home, or other",
+          code: "INVALID_VALUE"
       }]
       $ hasErrors = true
     }
@@ -411,9 +411,9 @@
   if input.sku != null && input.sku != "" {
     if input.sku.length() < 8 || input.sku.length() > 20 {
       $ errors = errors + [{
-        field: "sku",
-        message: "SKU must be 8-20 characters",
-        code: "LENGTH_ERROR"
+          field: "sku",
+          message: "SKU must be 8-20 characters",
+          code: "LENGTH_ERROR"
       }]
       $ hasErrors = true
     } else {
@@ -421,9 +421,9 @@
       $ existingSku = db.products.findOne("sku", input.sku)
       if existingSku != null {
         $ errors = errors + [{
-          field: "sku",
-          message: "SKU already exists",
-          code: "ALREADY_EXISTS"
+            field: "sku",
+            message: "SKU already exists",
+            code: "ALREADY_EXISTS"
         }]
         $ hasErrors = true
       }
@@ -439,12 +439,12 @@
     }
   } else {
     $ newProduct = db.products.create({
-      name: input.name,
-      price: input.price,
-      quantity: input.quantity,
-      category: input.category,
-      sku: input.sku,
-      created_at: now()
+        name: input.name,
+        price: input.price,
+        quantity: input.quantity,
+        category: input.category,
+        sku: input.sku,
+        created_at: now()
     })
 
     > {
@@ -467,25 +467,25 @@
   # Query parameter validation
   if input.q == null || input.q == "" {
     $ errors = errors + [{
-      field: "q",
-      message: "Search query is required",
-      code: "REQUIRED"
+        field: "q",
+        message: "Search query is required",
+        code: "REQUIRED"
     }]
     $ hasErrors = true
   } else {
     if input.q.length() < 2 {
       $ errors = errors + [{
-        field: "q",
-        message: "Search query must be at least 2 characters",
-        code: "MIN_LENGTH"
+          field: "q",
+          message: "Search query must be at least 2 characters",
+          code: "MIN_LENGTH"
       }]
       $ hasErrors = true
     } else {
       if input.q.length() > 100 {
         $ errors = errors + [{
-          field: "q",
-          message: "Search query cannot exceed 100 characters",
-          code: "MAX_LENGTH"
+            field: "q",
+            message: "Search query cannot exceed 100 characters",
+            code: "MAX_LENGTH"
         }]
         $ hasErrors = true
       }
@@ -496,9 +496,9 @@
   if input.page != null {
     if input.page < 1 {
       $ errors = errors + [{
-        field: "page",
-        message: "Page number must be at least 1",
-        code: "MIN_VALUE"
+          field: "page",
+          message: "Page number must be at least 1",
+          code: "MIN_VALUE"
       }]
       $ hasErrors = true
     }
@@ -508,9 +508,9 @@
   if input.limit != null {
     if input.limit < 1 || input.limit > 100 {
       $ errors = errors + [{
-        field: "limit",
-        message: "Limit must be between 1 and 100",
-        code: "OUT_OF_RANGE"
+          field: "limit",
+          message: "Limit must be between 1 and 100",
+          code: "OUT_OF_RANGE"
       }]
       $ hasErrors = true
     }

--- a/pkg/codegen/typescript_server.go
+++ b/pkg/codegen/typescript_server.go
@@ -974,12 +974,12 @@ func irTypeToTypeScript(t ir.TypeRef) string {
 		if t.Inner != nil {
 			return irTypeToTypeScript(*t.Inner) + "[]"
 		}
-		return "any[]"
+		return "unknown[]"
 	case ir.TypeOptional:
 		if t.Inner != nil {
 			return irTypeToTypeScript(*t.Inner) + " | null"
 		}
-		return "any | null"
+		return "unknown | null"
 	case ir.TypeNamed:
 		return t.Name
 	case ir.TypeProvider:
@@ -992,11 +992,11 @@ func irTypeToTypeScript(t ir.TypeRef) string {
 			}
 			return strings.Join(parts, " | ")
 		}
-		return "any"
+		return "unknown"
 	case ir.TypeAny:
-		return "any"
+		return "unknown"
 	default:
-		return "any"
+		return "unknown"
 	}
 }
 
@@ -1018,12 +1018,12 @@ func tsProviderToGetterFunc(providerType string) string {
 
 func tsTypeNameForInput(t *ir.TypeRef) string {
 	if t == nil {
-		return "any"
+		return "unknown"
 	}
 	if t.Kind == ir.TypeNamed {
 		return t.Name
 	}
-	return "any"
+	return irTypeToTypeScript(*t)
 }
 
 func tsCamelCase(s string) string {

--- a/pkg/codegen/typescript_server_test.go
+++ b/pkg/codegen/typescript_server_test.go
@@ -265,7 +265,7 @@ func TestIrTypeToTypeScript(t *testing.T) {
 		{"float", ir.TypeRef{Kind: ir.TypeFloat}, "number"},
 		{"string", ir.TypeRef{Kind: ir.TypeString}, "string"},
 		{"bool", ir.TypeRef{Kind: ir.TypeBool}, "boolean"},
-		{"any", ir.TypeRef{Kind: ir.TypeAny}, "any"},
+		{"any", ir.TypeRef{Kind: ir.TypeAny}, "unknown"},
 		{"named", ir.TypeRef{Kind: ir.TypeNamed, Name: "User"}, "User"},
 		{"array", ir.TypeRef{Kind: ir.TypeArray, Inner: &ir.TypeRef{Kind: ir.TypeInt}}, "number[]"},
 		{"optional", ir.TypeRef{Kind: ir.TypeOptional, Inner: &ir.TypeRef{Kind: ir.TypeString}}, "string | null"},
@@ -274,9 +274,9 @@ func TestIrTypeToTypeScript(t *testing.T) {
 			{Kind: ir.TypeString},
 			{Kind: ir.TypeInt},
 		}}, "string | number"},
-		{"array_nil_inner", ir.TypeRef{Kind: ir.TypeArray}, "any[]"},
-		{"optional_nil_inner", ir.TypeRef{Kind: ir.TypeOptional}, "any | null"},
-		{"union_empty", ir.TypeRef{Kind: ir.TypeUnion}, "any"},
+		{"array_nil_inner", ir.TypeRef{Kind: ir.TypeArray}, "unknown[]"},
+		{"optional_nil_inner", ir.TypeRef{Kind: ir.TypeOptional}, "unknown | null"},
+		{"union_empty", ir.TypeRef{Kind: ir.TypeUnion}, "unknown"},
 	}
 
 	for _, tt := range tests {
@@ -284,6 +284,27 @@ func TestIrTypeToTypeScript(t *testing.T) {
 			result := irTypeToTypeScript(tt.input)
 			if result != tt.expected {
 				t.Errorf("irTypeToTypeScript(%v) = %q, want %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestTsTypeNameForInput(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    *ir.TypeRef
+		expected string
+	}{
+		{"nil", nil, "unknown"},
+		{"named", &ir.TypeRef{Kind: ir.TypeNamed, Name: "User"}, "User"},
+		{"array_of_named", &ir.TypeRef{Kind: ir.TypeArray, Inner: &ir.TypeRef{Kind: ir.TypeNamed, Name: "Item"}}, "Item[]"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tsTypeNameForInput(tt.input)
+			if result != tt.expected {
+				t.Errorf("tsTypeNameForInput(%v) = %q, want %q", tt.input, result, tt.expected)
 			}
 		})
 	}

--- a/pkg/formatter/canonical.go
+++ b/pkg/formatter/canonical.go
@@ -1,0 +1,122 @@
+package formatter
+
+import (
+	"strings"
+)
+
+// CanonicalizeSource applies the canonical GlyphLang formatting rules to source
+// code. It is deliberately zero-option and line-preserving: content within a
+// line is never reflowed or reordered, so a one-line change stays a one-line
+// diff. Comments and strings are preserved byte-for-byte.
+//
+// Rules:
+//  1. Line endings are normalized to LF.
+//  2. Trailing whitespace is stripped from every line.
+//  3. Indentation is exactly 2 spaces per bracket depth ({, [, ( open; ), ], }
+//     close). A line whose first character is a closer indents at depth-1.
+//  4. At most one consecutive blank line; leading blank lines are removed.
+//  5. The file ends with exactly one newline (an empty file stays empty).
+func CanonicalizeSource(source string) string {
+	source = strings.TrimPrefix(source, "\ufeff") // strip UTF-8 BOM; the lexer rejects it
+	source = strings.ReplaceAll(source, "\r\n", "\n")
+	source = strings.ReplaceAll(source, "\r", "\n")
+
+	lines := strings.Split(source, "\n")
+	var out []string
+	depth := 0
+	blankRun := 0
+
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+
+		if trimmed == "" {
+			blankRun++
+			// Rule 4: no leading blanks, max one consecutive blank.
+			if len(out) > 0 && blankRun == 1 {
+				out = append(out, "")
+			}
+			continue
+		}
+		blankRun = 0
+
+		opens, closes, leadingCloses := scanBrackets(trimmed)
+
+		indent := depth
+		if leadingCloses > 0 {
+			indent -= leadingCloses
+		}
+		if indent < 0 {
+			indent = 0
+		}
+
+		out = append(out, strings.Repeat("  ", indent)+trimmed)
+
+		depth += opens - closes
+		if depth < 0 {
+			depth = 0
+		}
+	}
+
+	// Drop a trailing blank line left by rule 4.
+	for len(out) > 0 && out[len(out)-1] == "" {
+		out = out[:len(out)-1]
+	}
+
+	if len(out) == 0 {
+		return ""
+	}
+	return strings.Join(out, "\n") + "\n"
+}
+
+// scanBrackets counts bracket opens and closes on a single line, ignoring
+// brackets inside string literals and comments. leadingCloses is the number of
+// closing brackets before any other content, which dictates the dedent of the
+// line itself. GlyphLang strings and comments never span lines, so no state
+// carries between lines.
+func scanBrackets(line string) (opens, closes, leadingCloses int) {
+	leading := true
+	i := 0
+	n := len(line)
+	for i < n {
+		ch := line[i]
+
+		// Line comments run to end of line.
+		if ch == '#' || (ch == '/' && i+1 < n && line[i+1] == '/') {
+			break
+		}
+
+		// Skip string literals, honoring escapes.
+		if ch == '"' || ch == '\'' {
+			quote := ch
+			i++
+			for i < n && line[i] != quote {
+				if line[i] == '\\' && i+1 < n {
+					i++
+				}
+				i++
+			}
+			if i < n {
+				i++
+			}
+			leading = false
+			continue
+		}
+
+		switch ch {
+		case '{', '[', '(':
+			opens++
+			leading = false
+		case '}', ']', ')':
+			closes++
+			if leading {
+				leadingCloses++
+			}
+		default:
+			if ch != ' ' && ch != '\t' {
+				leading = false
+			}
+		}
+		i++
+	}
+	return opens, closes, leadingCloses
+}

--- a/pkg/formatter/canonical_test.go
+++ b/pkg/formatter/canonical_test.go
@@ -1,0 +1,131 @@
+package formatter
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCanonicalizeSource_Reindent(t *testing.T) {
+	input := "@ GET /users -> List[User] {\n\tdb <- Database\n      > db.users.Find()\n}\n"
+	expected := "@ GET /users -> List[User] {\n  db <- Database\n  > db.users.Find()\n}\n"
+	if got := CanonicalizeSource(input); got != expected {
+		t.Errorf("got %q, want %q", got, expected)
+	}
+}
+
+func TestCanonicalizeSource_NestedBlocks(t *testing.T) {
+	input := ": User {\nid: int!\nprofile: {\nname: str!\n}\n}\n"
+	expected := ": User {\n  id: int!\n  profile: {\n    name: str!\n  }\n}\n"
+	if got := CanonicalizeSource(input); got != expected {
+		t.Errorf("got %q, want %q", got, expected)
+	}
+}
+
+func TestCanonicalizeSource_CommentsPreserved(t *testing.T) {
+	input := "# top comment with { brace\n@ GET /x {\n// inner comment\n$ y = 1  # trailing comment\n}\n"
+	expected := "# top comment with { brace\n@ GET /x {\n  // inner comment\n  $ y = 1  # trailing comment\n}\n"
+	if got := CanonicalizeSource(input); got != expected {
+		t.Errorf("got %q, want %q", got, expected)
+	}
+}
+
+func TestCanonicalizeSource_StringsUntouched(t *testing.T) {
+	input := "@ GET /x {\n$ s = \"a { brace # hash // slash\"\n$ q = 'don\\'t } close'\n}\n"
+	expected := "@ GET /x {\n  $ s = \"a { brace # hash // slash\"\n  $ q = 'don\\'t } close'\n}\n"
+	if got := CanonicalizeSource(input); got != expected {
+		t.Errorf("got %q, want %q", got, expected)
+	}
+}
+
+func TestCanonicalizeSource_BlankLines(t *testing.T) {
+	input := "\n\n@ GET /a {\n> 1\n}\n\n\n\n@ GET /b {\n> 2\n}\n\n\n"
+	expected := "@ GET /a {\n  > 1\n}\n\n@ GET /b {\n  > 2\n}\n"
+	if got := CanonicalizeSource(input); got != expected {
+		t.Errorf("got %q, want %q", got, expected)
+	}
+}
+
+func TestCanonicalizeSource_StripsBOM(t *testing.T) {
+	input := "\ufeff# comment\n$ x = 1\n"
+	expected := "# comment\n$ x = 1\n"
+	if got := CanonicalizeSource(input); got != expected {
+		t.Errorf("got %q, want %q", got, expected)
+	}
+}
+
+func TestCanonicalizeSource_CRLF(t *testing.T) {
+	input := "@ GET /x {\r\n> 1\r\n}\r\n"
+	expected := "@ GET /x {\n  > 1\n}\n"
+	if got := CanonicalizeSource(input); got != expected {
+		t.Errorf("got %q, want %q", got, expected)
+	}
+}
+
+func TestCanonicalizeSource_TrailingWhitespaceAndNewline(t *testing.T) {
+	input := "$ x = 1   \n$ y = 2\t"
+	expected := "$ x = 1\n$ y = 2\n"
+	if got := CanonicalizeSource(input); got != expected {
+		t.Errorf("got %q, want %q", got, expected)
+	}
+}
+
+func TestCanonicalizeSource_EmptyFile(t *testing.T) {
+	if got := CanonicalizeSource(""); got != "" {
+		t.Errorf("empty input should stay empty, got %q", got)
+	}
+	if got := CanonicalizeSource("\n\n\n"); got != "" {
+		t.Errorf("blank-only input should become empty, got %q", got)
+	}
+}
+
+func TestCanonicalizeSource_CloserDedents(t *testing.T) {
+	input := "@ GET /x {\nif ok {\n> 1\n} else {\n> 2\n}\n}\n"
+	expected := "@ GET /x {\n  if ok {\n    > 1\n  } else {\n    > 2\n  }\n}\n"
+	if got := CanonicalizeSource(input); got != expected {
+		t.Errorf("got %q, want %q", got, expected)
+	}
+}
+
+func TestCanonicalizeSource_UnbalancedClampsAtZero(t *testing.T) {
+	input := "}\n}\n$ x = 1\n"
+	expected := "}\n}\n$ x = 1\n"
+	if got := CanonicalizeSource(input); got != expected {
+		t.Errorf("got %q, want %q", got, expected)
+	}
+}
+
+func TestCanonicalizeSource_Idempotent(t *testing.T) {
+	inputs := []string{
+		"@ GET /users -> List[User] {\n\tdb <- Database\n> db.users.Find()\n}\n",
+		"# comment\n\n\n: User {\nid: int!\n}\n",
+		"@ GET /x {\r\n$ s = \"str with } brace\"\r\n}\r\n",
+	}
+	for _, input := range inputs {
+		once := CanonicalizeSource(input)
+		twice := CanonicalizeSource(once)
+		if once != twice {
+			t.Errorf("not idempotent for %q:\nonce:  %q\ntwice: %q", input, once, twice)
+		}
+	}
+}
+
+func TestCanonicalizeSource_OneLineChangeOneLineDiff(t *testing.T) {
+	base := "@ GET /a {\n  > 1\n}\n\n@ GET /b {\n  > 2\n}\n"
+	edited := strings.Replace(base, "> 2", "> 3", 1)
+	gotBase := CanonicalizeSource(base)
+	gotEdited := CanonicalizeSource(edited)
+	baseLines := strings.Split(gotBase, "\n")
+	editedLines := strings.Split(gotEdited, "\n")
+	if len(baseLines) != len(editedLines) {
+		t.Fatalf("line counts differ: %d vs %d", len(baseLines), len(editedLines))
+	}
+	diff := 0
+	for i := range baseLines {
+		if baseLines[i] != editedLines[i] {
+			diff++
+		}
+	}
+	if diff != 1 {
+		t.Errorf("expected exactly 1 differing line, got %d", diff)
+	}
+}

--- a/pkg/ir/analyzer.go
+++ b/pkg/ir/analyzer.go
@@ -232,6 +232,11 @@ func (a *Analyzer) convertType(t ast.Type) TypeRef {
 		inner := a.convertType(v.InnerType)
 		return TypeRef{Kind: TypeOptional, Inner: &inner}
 	case ast.NamedType:
+		// The parser represents the builtin any type as a NamedType; map it
+		// to TypeAny so consumers never treat "any" as a user-defined type.
+		if v.Name == "any" {
+			return TypeRef{Kind: TypeAny}
+		}
 		return TypeRef{Kind: TypeNamed, Name: v.Name}
 	case ast.DatabaseType:
 		return TypeRef{Kind: TypeProvider, Name: "Database"}


### PR DESCRIPTION
## Summary

Addresses two headline GlyphLang claims that did not fully hold up in the codebase, surfaced by public criticism of the "no any" and "zero-option formatter" claims.

### 1. TypeScript server codegen emitted silent `any`
The server generator (`glyph codegen --lang typescript`) fell back to literal `any` for unresolved, empty-union, and nil-inner types, and the IR analyzer mapped the builtin `any` type to a *named* type reference, so a glyph `any` leaked into generated interfaces verbatim. This is exactly the "compiler papers over uncertainty" failure the language pitches against.

- `irTypeToTypeScript` fallbacks now emit `unknown` (matching the client generator).
- Non-named route input types delegate to the full type conversion (`Item[]`, `A | B`) instead of `any`.
- The IR analyzer maps `any` -> `TypeAny` so every consumer handles it uniformly (this also fixed Python codegen emitting invalid lowercase `any`).

**Intentional behavior change:** member access on a glyph `any`-typed value in generated TypeScript now fails strict compilation instead of silently passing. Deliberate `any` in provider stubs and dynamic handler params is unchanged.

### 2. No shipped formatter behind the "zero-option formatter" claim
Adds `glyph fmt <file|dir>`, a token-level canonical formatter:
- Never reflows content within a line — a one-line change stays a one-line diff.
- Preserves comments and strings byte-for-byte.
- Rules: LF line endings, stripped trailing whitespace, 2-space indent per bracket depth, at most one consecutive blank line, exactly one trailing newline, UTF-8 BOM removal.
- `--check` flag for CI; already-canonical files are not rewritten.
- Documented in `docs/CLI.md`.

All 43 example files are reformatted with `glyph fmt` as dogfooding (whitespace-only diff; all still validate).

## Test plan
- `go test ./pkg/codegen/ ./pkg/formatter/ ./pkg/ir/ ./cmd/glyph/` pass.
- E2E: `glyph codegen` on `blog-api` — only remaining `any` in output are the deliberate provider stubs.
- E2E: `glyph fmt examples/ --check` exits 0 after formatting, 1 on mangled input; idempotent; reformatted examples still validate.