### PR TITLE
chore: regenerate llms.txt from corrected spec

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -60,9 +60,8 @@ Each glyph symbol maps to a semantic concept, not a language keyword.
 | `?` | `validate` | Validation assertion |
 | `~` | `handle` | Event handler binding |
 | `*` | `cron` | Scheduled task |
-| `!` | `command` | CLI command definition |
+| `!` | `command` | CLI command or function definition |
 | `&` | `queue` | Queue worker definition |
-| `=` | `func` | Function definition |
 
 ### 2.1 Context Rules
 
@@ -177,9 +176,9 @@ Standard database provider methods follow CRUD semantics:
 @ METHOD /path/:param {
   + middleware(args)
   + ratelimit(N/window)
-  < InputType
+  < input: InputType
   % provider: ProviderType
-  ? condition :: statusCode "message"
+  ? validate_fn(args)
   $ variable = expression
   > returnValue :: statusCode
 }
@@ -207,6 +206,25 @@ Prefixed with `:` — e.g., `/users/:id/posts/:postId`
 + ratelimit(100/min)
 + ratelimit(1000/hour)
 ```
+
+### 5.5 Error Responses
+
+There is no one-line conditional guard. Handle error cases with `if` and an
+early return:
+
+```glyph
+@ GET /users/:id {
+  % db: Database
+  $ user = db.users.Get(id)
+  if user == null {
+    > {error: "user not found"}
+  }
+  > user :: 200
+}
+```
+
+A `:: statusCode` suffix is supported on returns at the top level of a route
+body; returns inside conditional blocks use the default status.
 
 ## 6. Background Tasks
 
@@ -336,7 +354,7 @@ item        = type_def | route | function | cron | event | queue
 
 type_def    = ":" IDENT [ "<" type_params ">" ] [ "impl" traits ] "{" { field } "}" ;
 route       = "@" method path "{" { route_stmt } "}" ;
-function    = "=" IDENT "(" params ")" [ "->" type ] "{" { statement } "}" ;
+function    = "!" IDENT "(" params ")" [ ( ":" | "->" ) type ] "{" { statement } "}" ;
 cron        = "*" STRING [ IDENT ] "{" { statement } "}" ;
 event       = "~" STRING "{" { statement } "}" ;
 queue       = "&" STRING "{" { statement } "}" ;
@@ -346,8 +364,8 @@ provider    = "provider" IDENT "{" { method_sig } "}" ;
 route_stmt  = middleware | injection | input_decl | validate | statement ;
 middleware  = "+" IDENT "(" args ")" ;
 injection   = "%" IDENT ":" type ;
-input_decl  = "<" type ;
-validate    = "?" expr "::" INTEGER [ STRING ] ;
+input_decl  = "<" IDENT ":" type ;
+validate    = "?" IDENT "(" [ args ] ")" ;
 statement   = assign | reassign | return | if | for | while | switch | expr_stmt ;
 assign      = "$" IDENT "=" expr ;
 return      = ">" expr [ "::" INTEGER ] ;


### PR DESCRIPTION
Post-merge regeneration after #293 (llms.txt) and #295 (spec fixes) landed, per the merge-ordering note in #295. Content now matches the deployed copy at glyphlang.dev/llms.txt. Generated with the llms.txt Makefile recipe (header + docs/GLYPH_NOTATION_SPEC.md).