### PR TITLE
feat: implement conditional guard statement

### DIFF
--- a/cmd/glyph/guard_test.go
+++ b/cmd/glyph/guard_test.go
@@ -1,0 +1,136 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/glyphlang/glyph/pkg/ast"
+	"github.com/glyphlang/glyph/pkg/interpreter"
+	"github.com/glyphlang/glyph/pkg/server"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// serveCompiled compiles the first route in src and performs one request
+// against the real compiled-route HTTP path.
+func serveCompiled(t *testing.T, src, method, path string) *httptest.ResponseRecorder {
+	t.Helper()
+	route, bytecode := compileFirstRoute(t, src)
+	router := server.NewRouter()
+	require.NoError(t, registerCompiledRoute(router, route, bytecode, nil))
+	handler := createHandler(router)
+
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, httptest.NewRequest(method, path, nil))
+	return w
+}
+
+func TestGuardFailureReturnsStatusAndError(t *testing.T) {
+	src := `@ GET /items/:id {
+  $ found = false
+  ? found :: 404 "item not found"
+  > {id: id}
+}`
+	w := serveCompiled(t, src, "GET", "/items/1")
+	assert.Equal(t, 404, w.Code)
+
+	var body map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	assert.Equal(t, "item not found", body["error"])
+}
+
+func TestGuardPassContinuesRoute(t *testing.T) {
+	src := `@ GET /items/:id {
+  $ found = true
+  ? found :: 404 "item not found"
+  > {id: id}
+}`
+	w := serveCompiled(t, src, "GET", "/items/7")
+	assert.Equal(t, 200, w.Code)
+
+	var body map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	assert.Equal(t, "7", body["id"])
+}
+
+func TestReturnStatusCode(t *testing.T) {
+	src := `@ POST /items {
+  > {ok: true} :: 201
+}`
+	w := serveCompiled(t, src, "POST", "/items")
+	assert.Equal(t, 201, w.Code)
+
+	var body map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	assert.Equal(t, true, body["ok"])
+}
+
+// serveInterpreted runs the first route in src through the interpreter path
+// (`glyph run --interpret`) rather than compiled bytecode.
+func serveInterpreted(t *testing.T, src, rawURL string) *interpreter.Response {
+	t.Helper()
+	module, err := parseSource(src)
+	require.NoError(t, err)
+
+	var route *ast.Route
+	for _, item := range module.Items {
+		if r, ok := item.(*ast.Route); ok {
+			route = r
+			break
+		}
+	}
+	require.NotNil(t, route)
+
+	parsed, err := url.Parse(rawURL)
+	require.NoError(t, err)
+	req, err := http.NewRequest("GET", rawURL, nil)
+	require.NoError(t, err)
+	req.URL = parsed
+
+	ctx := &server.Context{Request: req, PathParams: map[string]string{"id": "9"}}
+	resp, err := executeRoute(route, ctx, interpreter.NewInterpreter())
+	require.NoError(t, err)
+	return resp
+}
+
+func TestGuardInterpretedParity(t *testing.T) {
+	src := `@ GET /users/:id {
+  $ found = false
+  ? found :: 404 "user not found"
+  > {id: id}
+}`
+	resp := serveInterpreted(t, src, "http://localhost/users/9")
+	assert.Equal(t, 404, resp.StatusCode)
+
+	body, ok := resp.Body.(map[string]interface{})
+	require.True(t, ok, "expected map body, got %T", resp.Body)
+	assert.Equal(t, "user not found", body["error"])
+}
+
+func TestGuardInterpretedPassContinues(t *testing.T) {
+	src := `@ GET /users/:id {
+  $ found = true
+  ? found :: 404 "user not found"
+  > {ok: true} :: 200
+}`
+	resp := serveInterpreted(t, src, "http://localhost/users/9")
+	assert.Equal(t, 200, resp.StatusCode)
+}
+
+func TestGuardExpressionCondition(t *testing.T) {
+	// The exact shape the generation-accuracy eval produced (issue #294).
+	src := `@ GET /users/:id {
+  $ user = null
+  ? user != null :: 404 "user not found"
+  > user :: 200
+}`
+	w := serveCompiled(t, src, "GET", "/users/9")
+	assert.Equal(t, 404, w.Code)
+
+	var body map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	assert.Equal(t, "user not found", body["error"])
+}

--- a/cmd/glyph/handlers.go
+++ b/cmd/glyph/handlers.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/glyphlang/glyph/pkg/ast"
+	"github.com/glyphlang/glyph/pkg/compiler"
 	"github.com/glyphlang/glyph/pkg/database"
 	"github.com/glyphlang/glyph/pkg/interpreter"
 	"github.com/glyphlang/glyph/pkg/parser"
@@ -199,11 +200,38 @@ func createCompiledRouteHandler(route *ast.Route, bytecode []byte, wsHub *websoc
 			})
 		}
 
+		// Unwrap status-carrying results from guards and `> value :: N`
+		// (see compiler.StatusKey).
+		if body, status, ok := unwrapStatusResult(result); ok {
+			ctx.StatusCode = status
+			ctx.ResponseWriter.Header().Set("Content-Type", "application/json")
+			ctx.ResponseWriter.WriteHeader(status)
+			return json.NewEncoder(ctx.ResponseWriter).Encode(body)
+		}
+
 		// Set response
 		ctx.StatusCode = http.StatusOK
 		ctx.ResponseWriter.Header().Set("Content-Type", "application/json")
 		return json.NewEncoder(ctx.ResponseWriter).Encode(result)
 	}
+}
+
+// unwrapStatusResult detects the compiler's status marker object in a VM
+// result and returns its body and HTTP status code.
+func unwrapStatusResult(result vm.Value) (vm.Value, int, bool) {
+	obj, ok := result.(vm.ObjectValue)
+	if !ok {
+		return nil, 0, false
+	}
+	statusVal, ok := obj.Val[compiler.StatusKey]
+	if !ok {
+		return nil, 0, false
+	}
+	intVal, ok := statusVal.(vm.IntValue)
+	if !ok {
+		return nil, 0, false
+	}
+	return obj.Val[compiler.BodyKey], int(intVal.Val), true
 }
 
 // createRouteHandler creates an HTTP handler for a route
@@ -248,9 +276,13 @@ func createRouteHandler(route *ast.Route, interp *interpreter.Interpreter) serve
 			}
 		}
 
-		// Default JSON response
-		ctx.StatusCode = http.StatusOK
+		// Default JSON response, honoring the interpreter's status code
+		// (guards and `> value :: N` set non-200 values).
+		ctx.StatusCode = response.StatusCode
 		ctx.ResponseWriter.Header().Set("Content-Type", "application/json")
+		if response.StatusCode != http.StatusOK {
+			ctx.ResponseWriter.WriteHeader(response.StatusCode)
+		}
 		return json.NewEncoder(ctx.ResponseWriter).Encode(response.Body)
 	}
 }

--- a/docs/GLYPH_NOTATION_SPEC.md
+++ b/docs/GLYPH_NOTATION_SPEC.md
@@ -22,7 +22,7 @@ Each glyph symbol maps to a semantic concept, not a language keyword.
 | `+` | `middleware` | Attach middleware/modifier |
 | `%` | `use` | Inject a provider dependency |
 | `<` | `expects` | Declare expected input type |
-| `?` | `validate` | Validation assertion |
+| `?` | `validate` | Validation assertion or route guard |
 | `~` | `handle` | Event handler binding |
 | `*` | `cron` | Scheduled task |
 | `!` | `command` | CLI command or function definition |
@@ -144,6 +144,7 @@ Standard database provider methods follow CRUD semantics:
   < input: InputType
   % provider: ProviderType
   ? validate_fn(args)
+  ? condition :: statusCode "message"
   $ variable = expression
   > returnValue :: statusCode
 }
@@ -174,22 +175,33 @@ Prefixed with `:` — e.g., `/users/:id/posts/:postId`
 
 ### 5.5 Error Responses
 
-There is no one-line conditional guard. Handle error cases with `if` and an
-early return:
+A guard is the one-line form: if the condition is false, the route responds
+immediately with the given status code and the body `{"error": "message"}`.
+If the condition is true, execution continues.
 
 ```glyph
 @ GET /users/:id {
   % db: Database
   $ user = db.users.Get(id)
-  if user == null {
-    > {error: "user not found"}
-  }
+  ? user != null :: 404 "user not found"
   > user :: 200
 }
 ```
 
-A `:: statusCode` suffix is supported on returns at the top level of a route
-body; returns inside conditional blocks use the default status.
+The `?` sigil covers both forms, distinguished by what follows the condition:
+`? validate_fn(args)` is a validation assertion, `? condition :: 404 "msg"` is
+a guard. The message is optional (`? user != null :: 404`).
+
+For multi-statement error handling, use `if` with an early return:
+
+```glyph
+if user == null {
+  > {error: "user not found", code: "NOT_FOUND"}
+}
+```
+
+A `:: statusCode` suffix is supported on any return; without it, routes
+respond `200`.
 
 ## 6. Background Tasks
 
@@ -326,11 +338,12 @@ queue       = "&" STRING "{" { statement } "}" ;
 command     = "!" IDENT { param } "{" { statement } "}" ;
 provider    = "provider" IDENT "{" { method_sig } "}" ;
 
-route_stmt  = middleware | injection | input_decl | validate | statement ;
+route_stmt  = middleware | injection | input_decl | validate | guard | statement ;
 middleware  = "+" IDENT "(" args ")" ;
 injection   = "%" IDENT ":" type ;
 input_decl  = "<" IDENT ":" type ;
 validate    = "?" IDENT "(" [ args ] ")" ;
+guard       = "?" expr "::" INTEGER [ STRING ] ;
 statement   = assign | reassign | return | if | for | while | switch | expr_stmt ;
 assign      = "$" IDENT "=" expr ;
 return      = ">" expr [ "::" INTEGER ] ;

--- a/llms.txt
+++ b/llms.txt
@@ -57,7 +57,7 @@ Each glyph symbol maps to a semantic concept, not a language keyword.
 | `+` | `middleware` | Attach middleware/modifier |
 | `%` | `use` | Inject a provider dependency |
 | `<` | `expects` | Declare expected input type |
-| `?` | `validate` | Validation assertion |
+| `?` | `validate` | Validation assertion or route guard |
 | `~` | `handle` | Event handler binding |
 | `*` | `cron` | Scheduled task |
 | `!` | `command` | CLI command or function definition |
@@ -179,6 +179,7 @@ Standard database provider methods follow CRUD semantics:
   < input: InputType
   % provider: ProviderType
   ? validate_fn(args)
+  ? condition :: statusCode "message"
   $ variable = expression
   > returnValue :: statusCode
 }
@@ -209,22 +210,33 @@ Prefixed with `:` — e.g., `/users/:id/posts/:postId`
 
 ### 5.5 Error Responses
 
-There is no one-line conditional guard. Handle error cases with `if` and an
-early return:
+A guard is the one-line form: if the condition is false, the route responds
+immediately with the given status code and the body `{"error": "message"}`.
+If the condition is true, execution continues.
 
 ```glyph
 @ GET /users/:id {
   % db: Database
   $ user = db.users.Get(id)
-  if user == null {
-    > {error: "user not found"}
-  }
+  ? user != null :: 404 "user not found"
   > user :: 200
 }
 ```
 
-A `:: statusCode` suffix is supported on returns at the top level of a route
-body; returns inside conditional blocks use the default status.
+The `?` sigil covers both forms, distinguished by what follows the condition:
+`? validate_fn(args)` is a validation assertion, `? condition :: 404 "msg"` is
+a guard. The message is optional (`? user != null :: 404`).
+
+For multi-statement error handling, use `if` with an early return:
+
+```glyph
+if user == null {
+  > {error: "user not found", code: "NOT_FOUND"}
+}
+```
+
+A `:: statusCode` suffix is supported on any return; without it, routes
+respond `200`.
 
 ## 6. Background Tasks
 
@@ -361,11 +373,12 @@ queue       = "&" STRING "{" { statement } "}" ;
 command     = "!" IDENT { param } "{" { statement } "}" ;
 provider    = "provider" IDENT "{" { method_sig } "}" ;
 
-route_stmt  = middleware | injection | input_decl | validate | statement ;
+route_stmt  = middleware | injection | input_decl | validate | guard | statement ;
 middleware  = "+" IDENT "(" args ")" ;
 injection   = "%" IDENT ":" type ;
 input_decl  = "<" IDENT ":" type ;
 validate    = "?" IDENT "(" [ args ] ")" ;
+guard       = "?" expr "::" INTEGER [ STRING ] ;
 statement   = assign | reassign | return | if | for | while | switch | expr_stmt ;
 assign      = "$" IDENT "=" expr ;
 return      = ">" expr [ "::" INTEGER ] ;

--- a/pkg/ast/ast.go
+++ b/pkg/ast/ast.go
@@ -275,12 +275,43 @@ type DbQueryStatement struct {
 
 func (DbQueryStatement) isStatement() {}
 
-// ReturnStatement represents a return statement
+// ReturnStatement represents a return statement.
+// Status is the optional HTTP status code from `> value :: 201`;
+// 0 means unspecified (routes default to 200).
 type ReturnStatement struct {
-	Value Expr
+	Value  Expr
+	Status int
 }
 
 func (ReturnStatement) isStatement() {}
+
+// GuardStatement represents a route guard: `? condition :: statusCode "message"`.
+// If the condition evaluates to false, the route responds immediately with
+// Status and the body {"error": Message}; otherwise execution continues.
+type GuardStatement struct {
+	Condition Expr
+	Status    int
+	Message   string
+}
+
+func (GuardStatement) isStatement() {}
+
+// Desugar converts the guard into the equivalent if-statement so that
+// consumers (compiler, interpreter, IR) can reuse their existing
+// if/return handling.
+func (g GuardStatement) Desugar() IfStatement {
+	return IfStatement{
+		Condition: UnaryOpExpr{Op: Not, Right: g.Condition},
+		ThenBlock: []Statement{
+			ReturnStatement{
+				Value: ObjectExpr{Fields: []ObjectField{
+					{Key: "error", Value: LiteralExpr{Value: StringLiteral{Value: g.Message}}},
+				}},
+				Status: g.Status,
+			},
+		},
+	}
+}
 
 // BreakStatement represents a break statement to exit a loop
 type BreakStatement struct{}
@@ -1055,6 +1086,7 @@ func (WsSendStatement) isNode()      {}
 func (WsBroadcastStatement) isNode() {}
 func (WsCloseStatement) isNode()     {}
 func (ValidationStatement) isNode()  {}
+func (GuardStatement) isNode()       {}
 func (ExpressionStatement) isNode()  {}
 func (YieldStatement) isNode()       {}
 func (WebSocketEvent) isNode()       {}

--- a/pkg/compiler/compiler.go
+++ b/pkg/compiler/compiler.go
@@ -328,6 +328,8 @@ func normalizeStatement(stmt ast.Statement) ast.Statement {
 		return *s
 	case *ast.ValidationStatement:
 		return *s
+	case *ast.GuardStatement:
+		return *s
 	case *ast.ForStatement:
 		return *s
 	case *ast.SwitchStatement:
@@ -359,6 +361,10 @@ func (c *Compiler) compileStatement(stmt ast.Statement) error {
 		return c.compileWhileStatement(&s)
 	case ast.ValidationStatement:
 		return c.compileValidationStatement(&s)
+	case ast.GuardStatement:
+		// Compile via the equivalent if/return so no new opcodes are needed.
+		desugared := s.Desugar()
+		return c.compileIfStatement(&desugared)
 	case ast.ForStatement:
 		return c.compileForStatement(&s)
 	case ast.SwitchStatement:
@@ -439,8 +445,20 @@ func (c *Compiler) compileReassignStatement(stmt *ast.ReassignStatement) error {
 
 // compileReturnStatement compiles return statement
 func (c *Compiler) compileReturnStatement(stmt *ast.ReturnStatement) error {
+	value := stmt.Value
+
+	// A status-carrying return (`> value :: 201`) is wrapped in a marker
+	// object the HTTP handler unwraps into the response status line. This
+	// avoids a new opcode and a VM-level response type.
+	if stmt.Status != 0 {
+		value = ast.ObjectExpr{Fields: []ast.ObjectField{
+			{Key: StatusKey, Value: ast.LiteralExpr{Value: ast.IntLiteral{Value: int64(stmt.Status)}}},
+			{Key: BodyKey, Value: stmt.Value},
+		}}
+	}
+
 	// Compile return value
-	if err := c.compileExpression(stmt.Value); err != nil {
+	if err := c.compileExpression(value); err != nil {
 		return err
 	}
 
@@ -449,6 +467,15 @@ func (c *Compiler) compileReturnStatement(stmt *ast.ReturnStatement) error {
 
 	return nil
 }
+
+// StatusKey and BodyKey are the reserved object keys used to carry an HTTP
+// status code from compiled bytecode to the HTTP handler. User objects with
+// these keys would be misinterpreted; the keys are namespaced to make a
+// collision implausible.
+const (
+	StatusKey = "__glyph_status"
+	BodyKey   = "__glyph_body"
+)
 
 // compileIfStatement compiles if statement
 func (c *Compiler) compileIfStatement(stmt *ast.IfStatement) error {

--- a/pkg/formatter/formatter.go
+++ b/pkg/formatter/formatter.go
@@ -567,9 +567,14 @@ func (f *Formatter) formatStatement(stmt ast.Statement) {
 		f.formatReassign(v.Target, v.Value)
 
 	case ast.ReturnStatement:
-		f.formatReturn(v.Value)
+		f.formatReturn(v.Value, v.Status)
 	case *ast.ReturnStatement:
-		f.formatReturn(v.Value)
+		f.formatReturn(v.Value, v.Status)
+
+	case ast.GuardStatement:
+		f.formatGuard(v)
+	case *ast.GuardStatement:
+		f.formatGuard(*v)
 
 	case ast.IfStatement:
 		f.formatIf(v.Condition, v.ThenBlock, v.ElseBlock)
@@ -690,13 +695,30 @@ func (f *Formatter) formatReassign(target string, value ast.Expr) {
 	f.writeln("")
 }
 
-func (f *Formatter) formatReturn(value ast.Expr) {
+func (f *Formatter) formatReturn(value ast.Expr, status int) {
 	if f.mode == Expanded {
 		f.write("return ")
 	} else {
 		f.write("> ")
 	}
 	f.formatExpr(value)
+	if status != 0 {
+		f.write(fmt.Sprintf(" :: %d", status))
+	}
+	f.writeln("")
+}
+
+func (f *Formatter) formatGuard(stmt ast.GuardStatement) {
+	if f.mode == Expanded {
+		f.write("validate ")
+	} else {
+		f.write("? ")
+	}
+	f.formatExpr(stmt.Condition)
+	f.write(fmt.Sprintf(" :: %d", stmt.Status))
+	if stmt.Message != "" {
+		f.write(fmt.Sprintf(" %q", stmt.Message))
+	}
 	f.writeln("")
 }
 

--- a/pkg/interpreter/executor.go
+++ b/pkg/interpreter/executor.go
@@ -97,6 +97,9 @@ func (i *Interpreter) ExecuteStatement(stmt Statement, env *Environment) (interf
 	case ValidationStatement:
 		return i.executeValidation(s, env)
 
+	case GuardStatement:
+		return i.executeGuard(s, env)
+
 	case ReassignStatement:
 		return i.executeReassign(s, env)
 
@@ -277,7 +280,37 @@ func (i *Interpreter) executeReturn(stmt ReturnStatement, env *Environment) (int
 		return nil, err
 	}
 
+	// A status-carrying return (`> value :: 201`) becomes a StatusResponse
+	// that the route executor maps onto the HTTP status line.
+	if stmt.Status != 0 {
+		value = &StatusResponse{Body: value, StatusCode: stmt.Status}
+	}
+
 	// Return a special error to signal a return statement
+	return value, &returnValue{value: value}
+}
+
+// executeGuard executes a route guard: if the condition is false, respond
+// immediately with the guard's status code and {"error": message}.
+func (i *Interpreter) executeGuard(stmt GuardStatement, env *Environment) (interface{}, error) {
+	condition, err := i.EvaluateExpression(stmt.Condition, env)
+	if err != nil {
+		return nil, err
+	}
+
+	condBool, ok := condition.(bool)
+	if !ok {
+		return nil, fmt.Errorf("guard condition must be a boolean, got %T", condition)
+	}
+
+	if condBool {
+		return nil, nil
+	}
+
+	value := &StatusResponse{
+		Body:       map[string]interface{}{"error": stmt.Message},
+		StatusCode: stmt.Status,
+	}
 	return value, &returnValue{value: value}
 }
 

--- a/pkg/interpreter/interpreter.go
+++ b/pkg/interpreter/interpreter.go
@@ -669,6 +669,17 @@ func (i *Interpreter) ExecuteRoute(route *Route, request *Request) (*Response, e
 		}, nil
 	}
 
+	// Status-carrying JSON responses (guards and `> value :: N`) skip the
+	// declared-return-type check: guard error bodies intentionally differ
+	// from the route's success type.
+	if sr, ok := result.(*StatusResponse); ok {
+		return &Response{
+			StatusCode: sr.StatusCode,
+			Body:       sr.Body,
+			Headers:    make(map[string]string),
+		}, nil
+	}
+
 	// Validate return value matches declared return type
 	if route.ReturnType != nil {
 		if err := i.typeChecker.CheckType(result, route.ReturnType); err != nil {

--- a/pkg/interpreter/response_types.go
+++ b/pkg/interpreter/response_types.go
@@ -30,6 +30,14 @@ type RedirectResponse struct {
 	StatusCode int
 }
 
+// StatusResponse signals that the route wants to send a JSON response with an
+// explicit status code, from `> value :: 201` or a failed guard
+// (`? condition :: 404 "message"`).
+type StatusResponse struct {
+	Body       interface{}
+	StatusCode int
+}
+
 // ValidateRedirect checks that the URL is well-formed and the status code is a valid redirect code.
 func ValidateRedirect(rawURL string, statusCode int) error {
 	if _, err := url.Parse(rawURL); err != nil {

--- a/pkg/ir/analyzer.go
+++ b/pkg/ir/analyzer.go
@@ -777,6 +777,10 @@ func (a *Analyzer) convertStatement(stmt ast.Statement) StmtIR {
 	case ast.ValidationStatement:
 		expr := a.convertExpr(&s.Call)
 		return StmtIR{Kind: StmtValidate, Validate: &ValidateStmt{Call: expr}}
+	case *ast.GuardStatement:
+		return a.convertStatement(s.Desugar())
+	case ast.GuardStatement:
+		return a.convertStatement(s.Desugar())
 	case *ast.BreakStatement, ast.BreakStatement:
 		return StmtIR{Kind: StmtBreak, Break: true}
 	case *ast.ContinueStatement, ast.ContinueStatement:

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -1520,8 +1520,10 @@ func (p *Parser) parseRoute() (ast.Item, error) {
 			p.skipNewlines()
 
 		case QUESTION:
-			// Check if this is query param declaration (? name: type) or validation (? validate_fn())
-			if p.peek(1).Type == IDENT && p.peek(2).Type == COLON {
+			// Check if this is query param declaration (? name: type) or
+			// validation/guard (parsed by parseStatement). A double colon
+			// means a guard (? name :: 404), not a query param.
+			if p.peek(1).Type == IDENT && p.peek(2).Type == COLON && p.peek(3).Type != COLON {
 				p.advance() // consume ?
 				param, err := p.parseQueryParamDecl()
 				if err != nil {
@@ -1946,42 +1948,43 @@ func (p *Parser) parseRateLimit() (*ast.RateLimit, error) {
 func (p *Parser) parseStatement() (ast.Statement, error) {
 	switch p.current().Type {
 	case QUESTION:
-		// ? validate_fn(args)
+		// ? validate_fn(args)                 -- validation assertion
+		// ? condition :: statusCode "message" -- route guard
 		p.advance()
 
-		// Expect function call
-		funcName, err := p.expectIdent()
+		cond, err := p.parseExpr()
 		if err != nil {
 			return nil, err
 		}
 
-		if err := p.expect(LPAREN); err != nil {
-			return nil, err
-		}
-
-		var args []ast.Expr
-		for !p.check(RPAREN) && !p.isAtEnd() {
-			arg, err := p.parseExpr()
+		if p.check(COLON) && p.peek(1).Type == COLON {
+			p.advance()
+			p.advance()
+			status, err := p.expectStatusCode()
 			if err != nil {
 				return nil, err
 			}
-			args = append(args, arg)
-
-			if !p.match(COMMA) {
-				break
+			message := ""
+			if p.check(STRING) {
+				message = p.current().Literal
+				p.advance()
 			}
+			return ast.GuardStatement{
+				Condition: cond,
+				Status:    status,
+				Message:   message,
+			}, nil
 		}
 
-		if err := p.expect(RPAREN); err != nil {
-			return nil, err
+		if call, ok := cond.(ast.FunctionCallExpr); ok {
+			return ast.ValidationStatement{Call: call}, nil
 		}
 
-		return ast.ValidationStatement{
-			Call: ast.FunctionCallExpr{
-				Name: funcName,
-				Args: args,
-			},
-		}, nil
+		return nil, p.errorWithHint(
+			fmt.Sprintf("Expected '::' or a validation call after '?', but found %s", p.current().Type),
+			p.current(),
+			"Use '? validate_fn(args)' for validation or '? condition :: statusCode \"message\"' for a guard",
+		)
 
 	case DOLLAR:
 		// $ var = expr or $ obj.field = expr or $ var: Type = expr
@@ -2075,15 +2078,26 @@ func (p *Parser) parseStatement() (ast.Statement, error) {
 		}, nil
 
 	case GREATER:
-		// > expr
+		// > expr [:: statusCode]
 		p.advance()
 		value, err := p.parseExpr()
 		if err != nil {
 			return nil, err
 		}
 
+		status := 0
+		if p.check(COLON) && p.peek(1).Type == COLON {
+			p.advance()
+			p.advance()
+			status, err = p.expectStatusCode()
+			if err != nil {
+				return nil, err
+			}
+		}
+
 		return ast.ReturnStatement{
-			Value: value,
+			Value:  value,
+			Status: status,
 		}, nil
 
 	case IDENT:
@@ -3277,6 +3291,27 @@ func (p *Parser) expect(t TokenType) error {
 		return nil
 	}
 	return p.expectError(t, p.current())
+}
+
+// expectStatusCode consumes an INTEGER token and returns it as an HTTP status code.
+func (p *Parser) expectStatusCode() (int, error) {
+	if p.current().Type != INTEGER {
+		return 0, p.errorWithHint(
+			fmt.Sprintf("Expected HTTP status code after '::', but found %s", p.current().Type),
+			p.current(),
+			"Use an integer status code, e.g. ':: 404'",
+		)
+	}
+	status, err := strconv.Atoi(p.current().Literal)
+	if err != nil || status < 100 || status > 599 {
+		return 0, p.errorWithHint(
+			fmt.Sprintf("Invalid HTTP status code %q after '::'", p.current().Literal),
+			p.current(),
+			"Status codes must be integers between 100 and 599",
+		)
+	}
+	p.advance()
+	return status, nil
 }
 
 func (p *Parser) expectIdent() (string, error) {


### PR DESCRIPTION
Closes #294.

## Summary

Implements the one-line route guard the notation spec originally described and the parser never had:

```glyph
@ GET /users/:id {
  % db: Database
  $ user = db.users.Get(id)
  ? user != null :: 404 "user not found"
  > user :: 200
}
```

If the condition is false, the route responds immediately with the status code and `{"error": "message"}`; otherwise execution continues. The message is optional. This is the exact form claude-opus-5 wrote unprompted in the generation-accuracy eval, which is what motivated the issue.

The `?` sigil now covers both forms, disambiguated by whether `::` follows the expression: `? validate_fn(args)` is a validation assertion, `? condition :: 404 "msg"` is a guard. The route-level query-param lookahead (`? name: type`) was updated to check for a second colon so `? found :: 404` is not misread as a query param.

Also implements the **status suffix on returns** (`> value :: 201`), which parsed but was silently ignored at runtime - both engines now honor it. The guard shares this path.

## Design

`GuardStatement` carries a `Desugar()` method returning the equivalent `if !cond { > {error: msg} :: status }`, so the compiler and IR analyzer reuse existing if/return handling rather than growing new opcodes:

- **compiler**: guard compiles via the desugared if; status-carrying returns wrap the value in a namespaced marker object (`__glyph_status` / `__glyph_body`) that the HTTP handler unwraps into the status line. No new opcode, no VM-level response type.
- **interpreter**: `executeGuard` returns a `StatusResponse`, which bypasses the declared-return-type check - a guard's error body intentionally differs from the route's success type.
- **handlers**: both the compiled and interpreted paths now call `WriteHeader` for non-200 responses (previously the interpreted path set `ctx.StatusCode` for logging but always wrote a 200 status line).
- **formatter**: round-trips guards and status suffixes byte-identically.

## Test plan

- New `cmd/glyph/guard_test.go`: 6 tests covering guard failure (404 + error body), guard pass (continues to the normal return), the status suffix, and interpreter/VM parity for both outcomes. Includes the verbatim shape from the eval.
- `go test ./...` passes with no regressions (47 packages).
- `go vet ./...` clean.
- Formatter round-trip verified manually: guard survives `glyph fmt` unchanged.
- Both documented forms validate (with and without a message).

## Docs

Spec section 5.5 rewritten to lead with the guard, `if` + early return documented as the multi-statement alternative. Guard restored to the route template, added to the EBNF (`guard = "?" expr "::" INTEGER [ STRING ] ;`) and to `route_stmt`. Symbol table entry for `?` updated. `llms.txt` regenerated.

Note: the deployed glyphlang.dev/llms.txt should be refreshed from this spec after merge.
