### PR TITLE
ci: fail when llms.txt is stale relative to the spec

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,9 @@ jobs:
       - name: Run go vet
         run: go vet ./...
 
+      - name: Check llms.txt is current
+        run: make llms.txt && git diff --exit-code llms.txt
+
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v9
         continue-on-error: true  # Don't fail CI on lint issues for now


### PR DESCRIPTION
## Summary

`llms.txt` is generated from `docs/GLYPH_NOTATION_SPEC.md` by the `llms.txt` target in the Makefile, but nothing enforced that the committed file matches the spec it is generated from. That drift has happened more than once: the primer served at glyphlang.dev/llms.txt described syntax the spec had already corrected, and the generation-accuracy eval was measuring one while the site served the other.

Adds one step to the existing `lint` job:

```yaml
- name: Check llms.txt is current
  run: make llms.txt && git diff --exit-code llms.txt
```

A PR that edits the spec without regenerating now fails CI instead of merging a stale primer.

## Test plan

- Verified the recipe is idempotent on a clean `main`: regenerating produces no diff, so the check passes as-is.
- Verified the negative case: appending a line to `docs/GLYPH_NOTATION_SPEC.md` and regenerating makes `git diff --exit-code llms.txt` exit 1.

## Notes

This makes the repo's `llms.txt` the authoritative copy. The site copy in `GlyphLangSite/public/llms.txt` remains a manual mirror - automating that push needs a cross-repo token, which is deliberately deferred.
