### PR TITLE
fix(bench): build glyph from the working tree instead of using PATH

### DIFF
--- a/benchmarks/bench_generation_accuracy.py
+++ b/benchmarks/bench_generation_accuracy.py
@@ -89,9 +89,9 @@ FASTAPI_SYSTEM = (
 
 
 def find_glyph_binary() -> str:
-    exe = shutil.which("glyph")
-    if exe:
-        return exe
+    # Always build from the working tree. A `glyph` on PATH is whatever the user
+    # last installed, which silently scores generated code against an older
+    # language version - syntax this repo supports gets counted as a failure.
     out = Path(tempfile.mkdtemp(prefix="glyph_eval_")) / ("glyph.exe" if os.name == "nt" else "glyph")
     subprocess.run(["go", "build", "-o", str(out), "./cmd/glyph"], cwd=REPO_ROOT, check=True)
     return str(out)


### PR DESCRIPTION
## Summary

`find_glyph_binary()` preferred a `glyph` on PATH and only fell back to building from the repo. That means the eval scored generated code against whatever version was last installed on the machine, not the tree under test.

This produced a concrete false result. Re-running the eval after the guard statement merged (#298) reported **9/15**, with `path_param` and `crud` failing 3/3:

```
ERROR [syntax_error]: Error at line 10, column 10:
Expected (, but found !=
  > ? user != null :: 404 "user not found"
```

That is the pre-guard parser. The installed binary was v0.3.4, two merges behind. The models had read the current spec, written valid guard syntax, and been marked wrong by a stale validator. Validating the identical file both ways:

| binary | result |
|--------|--------|
| PATH install (v0.3.4) | syntax_error at 10:10 |
| built from `main` | valid - 1 types, 1 routes |

The bug was latent until now: while the spec had the guard removed, nothing generated guard syntax, so a stale binary and a current one agreed. Correcting the spec is what surfaced it.

## Change

Drop the PATH shortcut; always build from `REPO_ROOT`. A few seconds of `go build` per run, in exchange for the eval never again silently grading against a different language version.

## Test plan

Full matrix re-run with the fix, 5 tasks x 3 trials x 2 conditions:

```
glyph:   15/15 (1.0)
fastapi: 15/15 (1.0)
```

Every task passes 3/3 in both conditions. Parity with FastAPI is restored and the guard statement causes no generation regression. The FastAPI bar remains the lenient one (`ast.parse`, syntax only) while glyph is checked with `glyph validate` (syntax + semantics).
