### PR TITLE
fix: stop unstamped dev builds reporting a stale release version

### DIFF
--- a/cmd/glyph/main.go
+++ b/cmd/glyph/main.go
@@ -10,7 +10,11 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "0.4.0"
+// version is overridden at release time via -ldflags "-X main.version=$VERSION".
+// The default deliberately is not a release number: an unstamped binary was
+// built from source, and claiming a version it may not correspond to has
+// already caused confusion when debugging against an installed glyph.
+var version = "0.0.0-dev"
 
 func main() {
 	// Check if invoked with just a .glyph file (e.g., double-click on Windows)


### PR DESCRIPTION
## Summary

`cmd/glyph/main.go` hardcoded `var version = "0.4.0"` while the latest tag was `v0.7.0`. The release workflow stamps the real value with `-ldflags "-X main.version=$VERSION"`, so published binaries were always correct - but anything built with a plain `go build` reported itself as 0.4.0, three minor versions behind.

That is not cosmetic in practice. Locally built binaries are what you reach for when debugging against an installed `glyph`, and this session already lost time to a version mismatch between a binary and the spec it was validating against. A binary that misstates its own version makes that class of confusion harder to spot, not easier.

## Change

Default to `0.0.0-dev` instead of a release number. It is a valid semver prerelease, sorts below every real release, and cannot be mistaken for one. The comment records why the default is deliberately not a version number, so the next person does not "helpfully" bump it to match the current tag and reintroduce the drift.

The variable feeds three display surfaces - the cobra `Version` field, the REPL banner, and the MCP server's `Implementation.Version` - all free-form strings, so none constrain the format.

## Test plan

```
$ go build -o g_dev ./cmd/glyph && ./g_dev version
GlyphLang v0.0.0-dev

$ go build -ldflags="-X main.version=0.8.0" -o g_rel ./cmd/glyph && ./g_rel version
GlyphLang v0.8.0
```

Unstamped builds identify as dev; the release path is unaffected. `gofmt` clean, `go vet ./cmd/glyph/` clean.
