### PR TITLE
docs: standardize on GlyphLang in prose and add a trademark policy

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -15,7 +15,7 @@
 # Shell scripts
 *.sh text eol=lf
 
-# Glyph source files
+# GlyphLang source files
 *.glyph text eol=lf
 
 # Keep binary files as-is

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -55,7 +55,7 @@
 
 - name: "area:server"
   color: "0052cc"
-  description: Related to the Glyph server
+  description: Related to the GlyphLang server
 
 - name: "area:lsp"
   color: "0052cc"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -414,7 +414,7 @@ Indicate which part of the codebase is affected:
 | `area:compiler` | Compiler and code generation |
 | `area:vm` | Virtual machine |
 | `area:interpreter` | Interpreter |
-| `area:server` | Glyph server |
+| `area:server` | GlyphLang server |
 | `area:lsp` | Language Server Protocol implementation |
 | `area:cli` | Command-line interface |
 | `area:database` | Database functionality |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# Multi-stage Dockerfile for Glyph
+# Multi-stage Dockerfile for GlyphLang
 # Stage 1: Build Go CLI
 FROM golang:1.24-alpine AS builder
 

--- a/Makefile
+++ b/Makefile
@@ -133,11 +133,11 @@ lint:
 
 # Run the application
 run:
-	@echo "Running Glyph..."
+	@echo "Running GlyphLang..."
 	go run ./cmd/glyph run examples/hello-world/main.glyph
 
 dev:
-	@echo "Running Glyph in dev mode..."
+	@echo "Running GlyphLang in dev mode..."
 	go run ./cmd/glyph dev examples/rest-api/main.glyph --port 8080
 
 # Regenerate llms.txt (AI agent primer served at glyphlang.dev/llms.txt)

--- a/Makefile
+++ b/Makefile
@@ -142,7 +142,7 @@ dev:
 
 # Regenerate llms.txt (AI agent primer served at glyphlang.dev/llms.txt)
 llms.txt:
-	head -n 35 llms.txt > llms_header.tmp
+	head -n 38 llms.txt > llms_header.tmp
 	cat llms_header.tmp docs/GLYPH_NOTATION_SPEC.md > llms.txt
 	rm llms_header.tmp
 .PHONY: llms.txt

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ GlyphLang is built from the ground up to be:
 
 It compiles to a single static binary, includes a built-in HTTP server and database access, and minimizes files, syntax and configuration so both humans _and_ AI can move faster.
 
+GlyphLang™ runs `.glyph` sources on its own runtime, written in Go and distributed as a single static binary from [Releases](https://github.com/GlyphLang/GlyphLang/releases) — there is no package-manager install.
+
 ---
 
 **Why GlyphLang?**
@@ -40,9 +42,9 @@ Less code isn't just productivity. It directly reduces:
 - Maintenance surface area
 
 ```
-Glyph:  @ GET /users/:id -> User     (21 tokens)
-Python: @app.route('/users/<id>')... (35 tokens)
-Java:   @GetMapping("/users/{id}")...  (28 tokens)
+GlyphLang: @ GET /users/:id -> User     (21 tokens)
+Python:    @app.route('/users/<id>')... (35 tokens)
+Java:      @GetMapping("/users/{id}")...  (28 tokens)
 ```
 
 ---
@@ -534,7 +536,7 @@ glyph context --changed
 ### Standard Commands
 
 ```bash
-glyph run <file>            # Run a Glyph file
+glyph run <file>            # Run a GlyphLang file
 glyph dev <file>            # Development server with hot reload
 glyph compile <file>        # Compile to bytecode
 glyph decompile <file>      # Decompile bytecode
@@ -565,8 +567,8 @@ Token counts measured with [tiktoken](https://github.com/openai/tiktoken) on equ
 
 #### GPT-4 / GPT-3.5 (cl100k_base encoding)
 
-| Sample | Glyph | FastAPI | Flask | Java |
-|--------|-------|---------|-------|------|
+| Sample | GlyphLang | FastAPI | Flask | Java |
+|--------|-----------|---------|-------|------|
 | Hello World API | 16 | 20 | 37 | 45 |
 | User GET with Param | 24 | 28 | 35 | 28 |
 | Protected Route | 22 | 29 | 27 | 32 |
@@ -575,7 +577,7 @@ Token counts measured with [tiktoken](https://github.com/openai/tiktoken) on equ
 | CRUD API | 122 | 150 | 148 | 186 |
 | WebSocket Handler | 78 | 108 | 144 | 246 |
 | **Total** | **349** | **451** | **535** | **791** |
-| **vs Glyph** | — | **23% more** | **36% more** | **57% more** |
+| **vs GlyphLang** | — | **23% more** | **36% more** | **57% more** |
 
 #### Token Savings Summary
 
@@ -598,19 +600,19 @@ FastAPI Hello World (20 tokens):
       return {"message": "Hello"}      # return statement
 
 Flask Hello World (37 tokens):
-  from flask import Flask, jsonify     # 6 tokens (eliminated in Glyph)
+  from flask import Flask, jsonify     # 6 tokens (eliminated in GlyphLang)
   app = Flask(__name__)                # 6 tokens (eliminated)
   @app.route('/hello', methods=['GET'])# verbose decorator
   def hello():                         # function definition
       return jsonify({...})            # wrapper function
 
-Glyph Hello World (16 tokens):
+GlyphLang Hello World (16 tokens):
   @ GET /hello {
     > {message: "Hello, World!"}
   }
 ```
 
-Even against FastAPI (the most concise Python framework), Glyph saves 23% by eliminating the function definition ceremony.
+Even against FastAPI (the most concise Python framework), GlyphLang saves 23% by eliminating the function definition ceremony.
 
 *Run `python benchmarks/bench_ai_efficiency.py` to reproduce. Verify with tiktoken.*
 
@@ -665,3 +667,6 @@ By contributing, you agree to the [Contributor License Agreement](CONTRIBUTING.m
 ## License
 
 Apache License 2.0 - see [LICENSE](LICENSE) for details.
+
+The license does not grant rights to the GlyphLang name - see [TRADEMARK.md](TRADEMARK.md) for
+what you may use it for without asking (most things).

--- a/TRADEMARK.md
+++ b/TRADEMARK.md
@@ -1,0 +1,69 @@
+# GlyphLang Trademark Policy
+
+"GlyphLang" and "GlyphLang™" are trademarks of the GlyphLang project, used continuously in
+connection with this software since 2025-12-16. They are unregistered (common-law) marks; the ™
+symbol indicates a claim of rights, not a registration.
+
+This policy explains when you may use the name without asking. It is deliberately permissive:
+the goal is that people can find, discuss, and build on GlyphLang freely, while nobody can pass
+off something else as the official project.
+
+## The license does not cover the name
+
+GlyphLang's source is licensed under the Apache License 2.0. Section 6 of that license grants
+no trademark rights. Your right to use, modify, and redistribute the code is unaffected by this
+policy; your right to apply the *name* to what you distribute is governed by it.
+
+## What is not a trademark
+
+The following are functional parts of the software, not marks, and this policy does not restrict
+them:
+
+- The `glyph` command name and its subcommands.
+- The `.glyph` and `.glyphx` file extensions.
+- The `GLYPH_*` environment variable names.
+- Language syntax, symbol vocabulary, and the notation specification.
+
+Write a tool that emits `.glyph` files or shells out to `glyph` without asking anyone.
+
+## Uses that need no permission
+
+- Stating truthfully that your project works with, targets, supports, or is built on GlyphLang.
+- Writing tutorials, articles, books, courses, talks, or reviews about GlyphLang.
+- Redistributing official, unmodified GlyphLang binaries or source under the name.
+- Naming a package, plugin, or extension so it describes its function — `vscode-glyphlang`,
+  `glyphlang-mode`, `awesome-glyphlang` — provided it does not imply official status.
+- Academic, journalistic, and comparative use.
+
+## Uses that need written permission
+
+- Using "GlyphLang" (or a confusingly similar name) as the name of your company, product,
+  service, or domain.
+- Distributing a modified build under the GlyphLang name.
+- Naming something in a way that suggests it is official, endorsed, or maintained by the
+  project: `glyphlang-official`, "The GlyphLang Foundation", "GlyphLang Certified".
+- Merchandise, logos, and domain registrations containing the mark.
+
+## Modified versions
+
+Redistributing a patched or forked build is fine — Apache-2.0 says so. Do not call the result
+GlyphLang without permission. Either give it your own name, or state prominently that it is an
+unofficial build not produced by the GlyphLang project.
+
+## How to ask
+
+Open an issue at https://github.com/GlyphLang/GlyphLang/issues with the "trademark" label
+describing the intended use. Requests that are honest about what they are get approved quickly.
+
+## Attribution
+
+When you use the name, mark it on first prominent use and identify the owner somewhere in the
+document:
+
+> GlyphLang™ is a trademark of the GlyphLang project.
+
+---
+
+This policy may change. It is not legal advice, and it does not enlarge or reduce rights that
+exist under trademark law — including nominative fair use, which permits referring to a product
+by its name regardless of what any policy says.

--- a/benchmarks/BenchJava.java
+++ b/benchmarks/BenchJava.java
@@ -2,7 +2,7 @@ import java.util.*;
 import java.util.concurrent.TimeUnit;
 
 /**
- * Java Benchmark Suite for comparison with Glyph Language
+ * Java Benchmark Suite for comparison with GlyphLang Language
  * Compile: javac BenchJava.java
  * Run: java BenchJava
  */

--- a/benchmarks/bench_ai_efficiency.py
+++ b/benchmarks/bench_ai_efficiency.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 """
 AI Efficiency Benchmark - Compare token usage and generation efficiency
-across Glyph, FastAPI, Flask, and Java for equivalent functionality.
+across GlyphLang, FastAPI, Flask, and Java for equivalent functionality.
 
-This measures the token efficiency of Glyph's minimal-ceremony design.
+This measures the token efficiency of GlyphLang's minimal-ceremony design.
 Token counts are measured using tiktoken (OpenAI's tokenizer).
 
 Requirements:
@@ -479,7 +479,7 @@ def run_analysis():
     """Run full analysis and print results"""
 
     print("=" * 100)
-    print("AI EFFICIENCY BENCHMARK: Glyph vs FastAPI vs Flask vs Java")
+    print("AI EFFICIENCY BENCHMARK: GlyphLang vs FastAPI vs Flask vs Java")
     print("=" * 100)
     print("\nMeasuring token efficiency for AI/LLM code generation")
     print("Lower tokens = faster generation, lower cost\n")
@@ -507,7 +507,7 @@ def run_analysis():
             totals[lang]['tokens'] += analysis[lang]['tokens']
 
     # Print per-sample results
-    print(f"{'Sample':<25} {'Glyph':<8} {'FastAPI':<8} {'Flask':<8} {'Java':<8} {'Fast/Gly':<9} {'Flsk/Gly':<9} {'Java/Gly':<9}")
+    print(f"{'Sample':<25} {'GlyphLang':<8} {'FastAPI':<8} {'Flask':<8} {'Java':<8} {'Fast/Gly':<9} {'Flsk/Gly':<9} {'Java/Gly':<9}")
     print(f"{'(tokens)':<25} {'tok':<8} {'tok':<8} {'tok':<8} {'tok':<8} {'ratio':<9} {'ratio':<9} {'ratio':<9}")
     print("-" * 100)
 
@@ -524,7 +524,7 @@ def run_analysis():
 
     print(f"\n{'Language':<15} {'Total Chars':<15} {'Total Lines':<15} {'Total Tokens':<15}")
     print("-" * 60)
-    print(f"{'Glyph':<15} {totals['glyph']['chars']:<15} {totals['glyph']['lines']:<15} {totals['glyph']['tokens']:<15}")
+    print(f"{'GlyphLang':<15} {totals['glyph']['chars']:<15} {totals['glyph']['lines']:<15} {totals['glyph']['tokens']:<15}")
     print(f"{'FastAPI':<15} {totals['fastapi']['chars']:<15} {totals['fastapi']['lines']:<15} {totals['fastapi']['tokens']:<15}")
     print(f"{'Flask':<15} {totals['flask']['chars']:<15} {totals['flask']['lines']:<15} {totals['flask']['tokens']:<15}")
     print(f"{'Java':<15} {totals['java']['chars']:<15} {totals['java']['lines']:<15} {totals['java']['tokens']:<15}")
@@ -534,7 +534,7 @@ def run_analysis():
     flask_savings = round((1 - totals['glyph']['tokens'] / totals['flask']['tokens']) * 100, 1)
     java_savings = round((1 - totals['glyph']['tokens'] / totals['java']['tokens']) * 100, 1)
 
-    print(f"\n{'TOKEN SAVINGS WITH Glyph:':<40}")
+    print(f"\n{'TOKEN SAVINGS WITH GlyphLang:':<40}")
     print(f"  vs FastAPI: {fastapi_savings}% fewer tokens")
     print(f"  vs Flask:   {flask_savings}% fewer tokens")
     print(f"  vs Java:    {java_savings}% fewer tokens")
@@ -546,7 +546,7 @@ def run_analysis():
 
     models = ['gpt-4', 'claude-opus', 'claude-sonnet', 'gpt-3.5']
 
-    print(f"\n{'Model':<18} {'Glyph':<12} {'FastAPI':<12} {'Flask':<12} {'Java':<12} {'Glyph Savings':<15}")
+    print(f"\n{'Model':<18} {'GlyphLang':<12} {'FastAPI':<12} {'Flask':<12} {'Java':<12} {'GlyphLang Savings':<15}")
     print("-" * 100)
 
     for model in models:
@@ -566,7 +566,7 @@ def run_analysis():
 
     print("""
 +--------------------------------------------------------------------------------------------------+
-| Glyph's AI-First Design Advantages:                                                              |
+| GlyphLang's AI-First Design Advantages:                                                              |
 +--------------------------------------------------------------------------------------------------+
 |                                                                                                  |
 | 1. TOKEN EFFICIENCY                                                                              |

--- a/benchmarks/bench_python.py
+++ b/benchmarks/bench_python.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Python Benchmark Suite for comparison with Glyph Language
+Python Benchmark Suite for comparison with GlyphLang Language
 Run: python bench_python.py
 """
 

--- a/cmd/glyph/commands.go
+++ b/cmd/glyph/commands.go
@@ -149,7 +149,7 @@ func runDecompile(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-// runTest handles the test command - executes test blocks in a GLYPH file.
+// runTest handles the test command - executes test blocks in a GlyphLang file.
 // Argument count is validated by cobra.ExactArgs(1) before this function is called.
 // printWarning, printInfo are defined in this file (see helper functions section).
 func runTest(cmd *cobra.Command, args []string) error {
@@ -423,7 +423,7 @@ func runInit(cmd *cobra.Command, args []string) error {
 func runLSP(cmd *cobra.Command, args []string) error {
 	logFile, _ := cmd.Flags().GetString("log")
 
-	printInfo("Starting GLYPH Language Server...")
+	printInfo("Starting GlyphLang Language Server...")
 	if logFile != "" {
 		printInfo(fmt.Sprintf("Logging to: %s", logFile))
 	}

--- a/cmd/glyph/commands.go
+++ b/cmd/glyph/commands.go
@@ -149,7 +149,7 @@ func runDecompile(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-// runTest handles the test command - executes test blocks in a GlyphLang file.
+// runTest handles the test command - executes test blocks in a .glyph file.
 // Argument count is validated by cobra.ExactArgs(1) before this function is called.
 // printWarning, printInfo are defined in this file (see helper functions section).
 func runTest(cmd *cobra.Command, args []string) error {

--- a/cmd/glyph/commands_info.go
+++ b/cmd/glyph/commands_info.go
@@ -13,7 +13,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// runListCommands lists all commands in a GLYPH file
+// runListCommands lists all commands in a GlyphLang file
 func runListCommands(cmd *cobra.Command, args []string) error {
 	filePath := args[0]
 

--- a/cmd/glyph/commands_info.go
+++ b/cmd/glyph/commands_info.go
@@ -13,7 +13,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// runListCommands lists all commands in a GlyphLang file
+// runListCommands lists all commands in a .glyph file
 func runListCommands(cmd *cobra.Command, args []string) error {
 	filePath := args[0]
 

--- a/cmd/glyph/handlers.go
+++ b/cmd/glyph/handlers.go
@@ -28,7 +28,7 @@ import (
 	"github.com/glyphlang/glyph/pkg/websocket"
 )
 
-// parseSource parses GLYPH source using the Go parser
+// parseSource parses GlyphLang source using the Go parser
 func parseSource(source string) (*ast.Module, error) {
 	// Use Go parser
 	lexer := parser.NewLexer(source)
@@ -350,7 +350,7 @@ func executeRoute(route *ast.Route, ctx *server.Context, interp *interpreter.Int
 }
 
 // extractDevAuthData parses auth data from a bearer token for interpreted
-// (dev) mode. The interpreter does not have a JWT library, so GLYPH apps
+// (dev) mode. The interpreter does not have a JWT library, so GlyphLang apps
 // running in --interpret mode issue demo tokens with the format
 // "demo-token-<userID>-<username>". This function extracts user claims
 // from that format so routes declaring + auth(jwt) can access auth.user.
@@ -516,7 +516,7 @@ func changeExtension(path, newExt string) string {
 // Template content getters
 func getHelloWorldTemplate() string {
 	return `# Hello World Example
-# This is a simple GLYPH program
+# This is a simple GlyphLang program
 
 : Message {
   text: str!
@@ -536,7 +536,7 @@ func getHelloWorldTemplate() string {
 }
 
 func getRestAPITemplate() string {
-	return `# Example REST API in GLYPH
+	return `# Example REST API in GlyphLang
 
 : User {
   id: int!

--- a/cmd/glyph/handlers_query_test.go
+++ b/cmd/glyph/handlers_query_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// compileFirstRoute parses GLYPH source and returns the first route and its
+// compileFirstRoute parses GlyphLang source and returns the first route and its
 // compiled bytecode. Used by tests that need to exercise the compiled route
 // handler directly.
 func compileFirstRoute(t testing.TB, source string) (*ast.Route, []byte) {

--- a/cmd/glyph/main.go
+++ b/cmd/glyph/main.go
@@ -62,7 +62,7 @@ to rapidly build high-performance, secure backend applications.`,
 	// Run command
 	var runCmd = &cobra.Command{
 		Use:   "run <file>",
-		Short: "Run GlyphLang source file",
+		Short: "Run .glyph source file",
 		Args:  cobra.ExactArgs(1),
 		RunE:  runRun,
 	}
@@ -101,8 +101,8 @@ to rapidly build high-performance, secure backend applications.`,
 	// Exec command - execute CLI commands defined with @ command
 	var execCmd = &cobra.Command{
 		Use:   "exec <file> <command> [args...]",
-		Short: "Execute a CLI command defined in a GlyphLang file",
-		Long: `Execute CLI commands defined with @ command in a GlyphLang file.
+		Short: "Execute a CLI command defined in a .glyph file",
+		Long: `Execute CLI commands defined with @ command in a .glyph file.
 
 Example:
   # In my-cli.glyph:
@@ -116,10 +116,10 @@ Example:
 		RunE: runExec,
 	}
 
-	// List commands - list all commands in a GlyphLang file
+	// List commands - list all commands in a .glyph file
 	var listCmdsCmd = &cobra.Command{
 		Use:   "commands <file>",
-		Short: "List all CLI commands defined in a GlyphLang file",
+		Short: "List all CLI commands defined in a .glyph file",
 		Args:  cobra.ExactArgs(1),
 		RunE:  runListCommands,
 	}
@@ -162,8 +162,8 @@ Examples:
 	// Validate command - validate source files with structured errors
 	var validateCmd = &cobra.Command{
 		Use:   "validate <file>",
-		Short: "Validate a GlyphLang source file",
-		Long: `Validate a GlyphLang source file and report errors.
+		Short: "Validate a .glyph source file",
+		Long: `Validate a .glyph source file and report errors.
 
 By default, outputs human-readable error messages. Use --ai for structured
 JSON output optimized for AI agents to parse and fix issues.
@@ -361,8 +361,8 @@ Examples:
 	// Test command
 	var testCmd = &cobra.Command{
 		Use:   "test <file>",
-		Short: "Run tests defined in a GlyphLang file",
-		Long: `Execute all test blocks defined with 'test' keyword in a GlyphLang file.
+		Short: "Run tests defined in a .glyph file",
+		Long: `Execute all test blocks defined with 'test' keyword in a .glyph file.
 
 Example:
   test "should add numbers" {

--- a/cmd/glyph/main.go
+++ b/cmd/glyph/main.go
@@ -34,7 +34,7 @@ func main() {
 	var rootCmd = &cobra.Command{
 		Use:   "glyph",
 		Short: "AI Backend Compiler - A language for AI-generated backends",
-		Long: `GLYPH is a programming language specifically designed for AI agents
+		Long: `GlyphLang is a programming language specifically designed for AI agents
 to rapidly build high-performance, secure backend applications.`,
 		Version: version,
 	}
@@ -62,7 +62,7 @@ to rapidly build high-performance, secure backend applications.`,
 	// Run command
 	var runCmd = &cobra.Command{
 		Use:   "run <file>",
-		Short: "Run GLYPH source file",
+		Short: "Run GlyphLang source file",
 		Args:  cobra.ExactArgs(1),
 		RunE:  runRun,
 	}
@@ -101,8 +101,8 @@ to rapidly build high-performance, secure backend applications.`,
 	// Exec command - execute CLI commands defined with @ command
 	var execCmd = &cobra.Command{
 		Use:   "exec <file> <command> [args...]",
-		Short: "Execute a CLI command defined in a GLYPH file",
-		Long: `Execute CLI commands defined with @ command in a GLYPH file.
+		Short: "Execute a CLI command defined in a GlyphLang file",
+		Long: `Execute CLI commands defined with @ command in a GlyphLang file.
 
 Example:
   # In my-cli.glyph:
@@ -116,10 +116,10 @@ Example:
 		RunE: runExec,
 	}
 
-	// List commands - list all commands in a GLYPH file
+	// List commands - list all commands in a GlyphLang file
 	var listCmdsCmd = &cobra.Command{
 		Use:   "commands <file>",
-		Short: "List all CLI commands defined in a GLYPH file",
+		Short: "List all CLI commands defined in a GlyphLang file",
 		Args:  cobra.ExactArgs(1),
 		RunE:  runListCommands,
 	}
@@ -128,7 +128,7 @@ Example:
 	var contextCmd = &cobra.Command{
 		Use:   "context [path]",
 		Short: "Generate AI-optimized context for the project",
-		Long: `Generate compact, cacheable context for AI agents working with this Glyph project.
+		Long: `Generate compact, cacheable context for AI agents working with this GlyphLang project.
 
 The context includes:
 - Type definitions with field signatures
@@ -162,8 +162,8 @@ Examples:
 	// Validate command - validate source files with structured errors
 	var validateCmd = &cobra.Command{
 		Use:   "validate <file>",
-		Short: "Validate a GLYPH source file",
-		Long: `Validate a GLYPH source file and report errors.
+		Short: "Validate a GlyphLang source file",
+		Long: `Validate a GlyphLang source file and report errors.
 
 By default, outputs human-readable error messages. Use --ai for structured
 JSON output optimized for AI agents to parse and fix issues.
@@ -238,8 +238,8 @@ Examples:
 	// OpenAPI command - generate OpenAPI 3.0 specification
 	var openapiCmd = &cobra.Command{
 		Use:   "openapi <file>",
-		Short: "Generate OpenAPI 3.0 specification from GLYPH source",
-		Long: `Generate an OpenAPI 3.0 specification from your GLYPH source code.
+		Short: "Generate OpenAPI 3.0 specification from GlyphLang source",
+		Long: `Generate an OpenAPI 3.0 specification from your GlyphLang source code.
 
 Analyzes route definitions, type definitions, authentication middleware,
 and query parameters to produce a complete OpenAPI 3.0 specification.
@@ -264,8 +264,8 @@ Examples:
 	// Docs command - generate API documentation
 	var docsCmd = &cobra.Command{
 		Use:   "docs <file>",
-		Short: "Generate API documentation from GLYPH source",
-		Long: `Generate API documentation from your GLYPH source code.
+		Short: "Generate API documentation from GlyphLang source",
+		Long: `Generate API documentation from your GlyphLang source code.
 
 Reads route definitions and type definitions to produce documentation
 with endpoint listings, request/response schemas, and type definitions.
@@ -289,8 +289,8 @@ Examples:
 	// Client command - generate API client code
 	var clientCmd = &cobra.Command{
 		Use:   "client <file>",
-		Short: "Generate API client code from GLYPH source",
-		Long: `Generate a typed API client from your GLYPH source code.
+		Short: "Generate API client code from GlyphLang source",
+		Long: `Generate a typed API client from your GlyphLang source code.
 
 Reads route definitions and type definitions to produce a fully typed
 API client with methods for each endpoint.
@@ -312,8 +312,8 @@ Examples:
 	// Codegen command - generate server code for target languages
 	var codegenCmd = &cobra.Command{
 		Use:   "codegen <file>",
-		Short: "Generate server code for a target language from GLYPH source",
-		Long: `Generate a complete server application from your GLYPH source code.
+		Short: "Generate server code for a target language from GlyphLang source",
+		Long: `Generate a complete server application from your GlyphLang source code.
 
 Parses the .glyph file, transforms it through the Semantic IR, and generates
 a working server application in the target language.
@@ -340,7 +340,7 @@ Examples:
 		Long: `Start an interactive Read-Eval-Print Loop (REPL) for GlyphLang.
 
 The REPL allows you to:
-- Execute Glyph expressions and statements interactively
+- Execute GlyphLang expressions and statements interactively
 - Explore language features and test code snippets
 - Inspect variables and their values
 
@@ -361,8 +361,8 @@ Examples:
 	// Test command
 	var testCmd = &cobra.Command{
 		Use:   "test <file>",
-		Short: "Run tests defined in a GLYPH file",
-		Long: `Execute all test blocks defined with 'test' keyword in a GLYPH file.
+		Short: "Run tests defined in a GlyphLang file",
+		Long: `Execute all test blocks defined with 'test' keyword in a GlyphLang file.
 
 Example:
   test "should add numbers" {

--- a/cmd/glyph/mcp_test.go
+++ b/cmd/glyph/mcp_test.go
@@ -34,5 +34,5 @@ func TestMCPValidateNoInput(t *testing.T) {
 func TestMCPSyntaxReference(t *testing.T) {
 	_, out, err := mcpSyntax(context.Background(), nil, syntaxInput{})
 	require.NoError(t, err)
-	assert.Contains(t, out.Spec, "Glyph Notation Specification")
+	assert.Contains(t, out.Spec, "GlyphLang Notation Specification")
 }

--- a/deploy/DEPLOYMENT_GUIDE.md
+++ b/deploy/DEPLOYMENT_GUIDE.md
@@ -1,6 +1,6 @@
-# Glyph Deployment Guide
+# GlyphLang Deployment Guide
 
-This guide covers deploying Glyph applications to production environments using Docker, Kubernetes, and cloud providers.
+This guide covers deploying GlyphLang applications to production environments using Docker, Kubernetes, and cloud providers.
 
 ## Table of Contents
 
@@ -17,7 +17,7 @@ This guide covers deploying Glyph applications to production environments using 
 ### Quick Start with Docker Compose
 
 ```bash
-# Start all services (Glyph app + PostgreSQL + Redis + Monitoring)
+# Start all services (GlyphLang app + PostgreSQL + Redis + Monitoring)
 docker-compose up -d
 
 # View logs
@@ -88,7 +88,7 @@ kubectl apply -f deploy/kubernetes/postgres.yaml
 # Deploy Redis
 kubectl apply -f deploy/kubernetes/redis.yaml
 
-# Deploy Glyph application
+# Deploy GlyphLang application
 kubectl apply -f deploy/kubernetes/deployment.yaml
 
 # Create ingress (optional)
@@ -201,7 +201,7 @@ kubectl apply -f deploy/kubernetes/
 
 ### Prometheus Metrics
 
-Glyph exposes metrics at `/metrics`:
+GlyphLang exposes metrics at `/metrics`:
 
 ```
 # Request metrics
@@ -227,7 +227,7 @@ glyph_database_queries_total
 kubectl port-forward svc/grafana 3000:3000 -n glyph
 
 # Login: admin / admin
-# Pre-configured dashboard at: Glyph Application Metrics
+# Pre-configured dashboard at: GlyphLang Application Metrics
 ```
 
 ### Log Aggregation
@@ -391,4 +391,4 @@ For deployment issues:
 ---
 
 *Last Updated: 2025-12-09*
-*Glyph Version: 1.0.0-production*
+*GlyphLang Version: 1.0.0-production*

--- a/deploy/grafana/dashboards/glyph-dashboard.json
+++ b/deploy/grafana/dashboards/glyph-dashboard.json
@@ -1,6 +1,6 @@
 {
   "dashboard": {
-    "title": "Glyph Application Metrics",
+    "title": "GlyphLang Application Metrics",
     "tags": ["glyph", "application"],
     "timezone": "browser",
     "panels": [

--- a/deploy/prometheus/prometheus.yml
+++ b/deploy/prometheus/prometheus.yml
@@ -18,7 +18,7 @@ rule_files:
 
 # Scrape configurations
 scrape_configs:
-  # Glyph application metrics
+  # GlyphLang application metrics
   - job_name: 'glyph-app'
     kubernetes_sd_configs:
       - role: pod

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.8'
 
 services:
-  # Glyph Application
+  # GlyphLang Application
   glyph:
     build:
       context: .
@@ -14,7 +14,7 @@ services:
       - Glyph_PORT=8080
       - Glyph_LOG_LEVEL=info
     volumes:
-      # Mount your Glyph application
+      # Mount your GlyphLang application
       - ./examples:/app/examples:ro
     restart: unless-stopped
     networks:

--- a/docs/BINARY_FORMAT.md
+++ b/docs/BINARY_FORMAT.md
@@ -1,7 +1,7 @@
-# Glyph Binary Format Specification
+# GlyphLang Binary Format Specification
 
 **Version:** 1.0
-**Purpose:** AI-optimized compact representation of Glyph programs
+**Purpose:** AI-optimized compact representation of GlyphLang programs
 
 ## Design Principles
 
@@ -14,9 +14,9 @@
 
 ```
 ┌──────────────────────────────────────────────┐
-│ Glyph Binary Format (.glyphc)                   │
+│ GlyphLang Binary Format (.glyphc)                   │
 ├──────────────────────────────────────────────┤
-│ [Magic Number: 4 bytes] "Glyph"               │
+│ [Magic Number: 4 bytes] "GlyphLang"               │
 │ [Version: 1 byte] 0x01                       │
 │ [Flags: 1 byte] compression, etc.            │
 │ [Item Count: 2 bytes] number of items        │
@@ -97,7 +97,7 @@
 
 **Binary format (.glyphc) - Hex dump:**
 ```
-41 49 42 43        // Magic: "Glyph"
+41 49 42 43        // Magic: "GlyphLang"
 01                 // Version: 1
 00                 // Flags: none
 01 00              // Item count: 1

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -1,6 +1,6 @@
-# Glyph CLI Documentation
+# GlyphLang CLI Documentation
 
-The Glyph command-line interface (CLI) provides tools for developing, running, and deploying Glyph applications.
+The GlyphLang command-line interface (CLI) provides tools for developing, running, and deploying GlyphLang applications.
 
 ## Installation
 
@@ -64,7 +64,7 @@ When you save changes, you'll see:
 
 ### `glyph run <file>`
 
-Run a Glyph source file or bytecode (production mode).
+Run a GlyphLang source file or bytecode (production mode).
 
 ```bash
 glyph run examples/rest-api/main.glyph
@@ -76,7 +76,7 @@ glyph run examples/rest-api/main.glyph
 ```
 
 **Features:**
-- Compiles and runs Glyph source using VM (default)
+- Compiles and runs GlyphLang source using VM (default)
 - Falls back to interpreter if compilation fails
 - Supports direct bytecode execution with `--bytecode`
 - Starts HTTP server
@@ -104,7 +104,7 @@ $ glyph run examples/rest-api/main.glyph --interpret
 
 ### `glyph compile <file>`
 
-Compile Glyph source code to bytecode.
+Compile GlyphLang source code to bytecode.
 
 ```bash
 glyph compile examples/hello-world/main.glyph
@@ -202,13 +202,13 @@ Content within a line is never reflowed, so a one-line change stays a one-line d
 
 ### `glyph exec <file> <command> [args...]`
 
-Execute a CLI command defined in a Glyph source file.
+Execute a CLI command defined in a GlyphLang source file.
 
 ```bash
 glyph exec main.glyph hello --name="Alice"
 
 # Arguments and flags:
-#   <file>        The Glyph source file containing commands
+#   <file>        The GlyphLang source file containing commands
 #   <command>     The name of the command to execute
 #   [args...]     Command-specific arguments and flags
 ```
@@ -252,7 +252,7 @@ $ glyph exec examples/cli-demo/main.glyph greet --name="Bob" --formal
 
 ### `glyph commands <file>`
 
-List all available CLI commands defined in a Glyph source file.
+List all available CLI commands defined in a GlyphLang source file.
 
 ```bash
 glyph commands main.glyph
@@ -292,7 +292,7 @@ Available commands in examples/cli-demo/main.glyph:
 
 ### `glyph context [directory]`
 
-Generate AI-optimized project context for AI agents working with Glyph codebases.
+Generate AI-optimized project context for AI agents working with GlyphLang codebases.
 
 ```bash
 glyph context              # Generate context for current directory
@@ -331,7 +331,7 @@ Changed: User.email type modified
 
 ### `glyph validate <file>`
 
-Validate Glyph source files with structured, AI-friendly error output.
+Validate GlyphLang source files with structured, AI-friendly error output.
 
 ```bash
 glyph validate main.glyph       # Human-readable output
@@ -444,7 +444,7 @@ $ glyph ir api.glyph --format catalog --pretty
 
 ### `glyph init <name>`
 
-Initialize a new Glyph project.
+Initialize a new GlyphLang project.
 
 ```bash
 glyph init my-project
@@ -470,11 +470,11 @@ $ glyph init my-api -t rest-api
 
 ### `glyph --version`
 
-Display Glyph version.
+Display GlyphLang version.
 
 ```bash
 $ glyph --version
-Glyph version 0.3.2
+GlyphLang v0.3.2
 ```
 
 ### `glyph --help`
@@ -483,7 +483,7 @@ Display help information.
 
 ```bash
 $ glyph --help
-Glyph is a programming language specifically designed for AI agents
+GlyphLang is a programming language specifically designed for AI agents
 to rapidly build high-performance, secure backend applications.
 
 Usage:
@@ -496,9 +496,9 @@ Available Commands:
   dev         Start development server with hot reload
   fmt         Format .glyph files with the canonical zero-option style
   init        Initialize new project
-  run         Run Glyph source file or bytecode
-  exec        Execute a CLI command from a Glyph file
-  commands    List all CLI commands in a Glyph file
+  run         Run GlyphLang source file or bytecode
+  exec        Execute a CLI command from a GlyphLang file
+  commands    List all CLI commands in a GlyphLang file
   validate    Validate source with structured errors
   lsp         Start Language Server Protocol server
   help        Help about any command
@@ -700,7 +700,7 @@ The CLI orchestrates four main components:
 
 ```
 ┌─────────────────┐
-│   Glyph CLI     │
+│   GlyphLang CLI     │
 │   (main.go)     │
 └────────┬────────┘
          │
@@ -739,7 +739,7 @@ The [VS Code extension](https://github.com/GlyphLang/vscode-glyph) automatically
 
 ## JIT Compilation
 
-Glyph includes a JIT (Just-In-Time) compiler that automatically optimizes frequently executed routes for better performance.
+GlyphLang includes a JIT (Just-In-Time) compiler that automatically optimizes frequently executed routes for better performance.
 
 ### How It Works
 
@@ -762,7 +762,7 @@ JIT compilation is **enabled by default** in production mode. The runtime automa
 
 ### Configuration
 
-JIT behavior can be tuned programmatically when embedding Glyph:
+JIT behavior can be tuned programmatically when embedding GlyphLang:
 
 ```go
 import "github.com/glyphlang/glyph/pkg/jit"
@@ -801,11 +801,11 @@ The JIT compiler tracks runtime types and generates specialized code for monomor
 
 ## Observability
 
-Glyph provides built-in observability through Prometheus metrics and OpenTelemetry tracing.
+GlyphLang provides built-in observability through Prometheus metrics and OpenTelemetry tracing.
 
 ### Prometheus Metrics
 
-Glyph exposes metrics at the `/metrics` endpoint in Prometheus format.
+GlyphLang exposes metrics at the `/metrics` endpoint in Prometheus format.
 
 #### Enabling Metrics
 
@@ -877,7 +877,7 @@ scrape_configs:
 
 ### OpenTelemetry Tracing
 
-Glyph supports distributed tracing via OpenTelemetry with W3C Trace Context propagation.
+GlyphLang supports distributed tracing via OpenTelemetry with W3C Trace Context propagation.
 
 #### Enabling Tracing
 
@@ -962,7 +962,7 @@ docker run -d --name jaeger \
 
 ## Environment Variables
 
-Glyph applications can be configured via environment variables.
+GlyphLang applications can be configured via environment variables.
 
 ### Core Variables
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -64,7 +64,7 @@ When you save changes, you'll see:
 
 ### `glyph run <file>`
 
-Run a GlyphLang source file or bytecode (production mode).
+Run a `.glyph` source file or bytecode (production mode).
 
 ```bash
 glyph run examples/rest-api/main.glyph
@@ -202,13 +202,13 @@ Content within a line is never reflowed, so a one-line change stays a one-line d
 
 ### `glyph exec <file> <command> [args...]`
 
-Execute a CLI command defined in a GlyphLang source file.
+Execute a CLI command defined in a `.glyph` source file.
 
 ```bash
 glyph exec main.glyph hello --name="Alice"
 
 # Arguments and flags:
-#   <file>        The GlyphLang source file containing commands
+#   <file>        The `.glyph` source file containing commands
 #   <command>     The name of the command to execute
 #   [args...]     Command-specific arguments and flags
 ```
@@ -252,7 +252,7 @@ $ glyph exec examples/cli-demo/main.glyph greet --name="Bob" --formal
 
 ### `glyph commands <file>`
 
-List all available CLI commands defined in a GlyphLang source file.
+List all available CLI commands defined in a `.glyph` source file.
 
 ```bash
 glyph commands main.glyph
@@ -331,7 +331,7 @@ Changed: User.email type modified
 
 ### `glyph validate <file>`
 
-Validate GlyphLang source files with structured, AI-friendly error output.
+Validate `.glyph` source files with structured, AI-friendly error output.
 
 ```bash
 glyph validate main.glyph       # Human-readable output
@@ -496,9 +496,9 @@ Available Commands:
   dev         Start development server with hot reload
   fmt         Format .glyph files with the canonical zero-option style
   init        Initialize new project
-  run         Run GlyphLang source file or bytecode
-  exec        Execute a CLI command from a GlyphLang file
-  commands    List all CLI commands in a GlyphLang file
+  run         Run `.glyph` source file or bytecode
+  exec        Execute a CLI command from a `.glyph` file
+  commands    List all CLI commands in a `.glyph` file
   validate    Validate source with structured errors
   lsp         Start Language Server Protocol server
   help        Help about any command

--- a/docs/GLYPH_NOTATION_SPEC.md
+++ b/docs/GLYPH_NOTATION_SPEC.md
@@ -1,13 +1,13 @@
-# Glyph Notation Specification
+# GlyphLang Notation Specification
 
 **Version:** 0.1.0-draft
 **Status:** Working draft
 
 ## 1. Overview
 
-Glyph notation is a compact, typed, language-neutral notation for describing backend services. It is designed to be consumed by both humans and AI systems, and can be compiled, interpreted, or used as a structured intent language for code generation in any target language.
+GlyphLang notation is a compact, typed, language-neutral notation for describing backend services. It is designed to be consumed by both humans and AI systems, and can be compiled, interpreted, or used as a structured intent language for code generation in any target language.
 
-A Glyph program describes **what a service does**, not how it does it in any specific language.
+A GlyphLang program describes **what a service does**, not how it does it in any specific language.
 
 ## 2. Symbol Vocabulary
 
@@ -76,8 +76,8 @@ Fields marked with `!` are required. Fields marked with `?` are optional. Fields
 
 ### 3.4 Target Language Type Mapping
 
-| Glyph | Python | TypeScript | Go | Java | Rust |
-|-------|--------|------------|-----|------|------|
+| GlyphLang | Python | TypeScript | Go | Java | Rust |
+|-----------|--------|------------|-----|------|------|
 | `int` | `int` | `number` | `int64` | `long` | `i64` |
 | `float` | `float` | `number` | `float64` | `double` | `f64` |
 | `str` | `str` | `string` | `string` | `String` | `String` |
@@ -236,7 +236,7 @@ respond `200`.
 
 ## 7. Semantic IR
 
-The Semantic IR is the language-neutral intermediate representation produced by analyzing a Glyph program. It captures intent independent of any target language.
+The Semantic IR is the language-neutral intermediate representation produced by analyzing a GlyphLang program. It captures intent independent of any target language.
 
 ### 7.1 IR Structure
 
@@ -283,7 +283,7 @@ All expressions are normalized into a flat, discriminated union:
 
 ## 8. Compact vs Expanded Syntax
 
-Every Glyph program has two equivalent representations:
+Every GlyphLang program has two equivalent representations:
 
 **Compact** (`.glyph`): Uses symbols for maximum token efficiency
 ```
@@ -359,7 +359,7 @@ method      = "GET" | "POST" | "PUT" | "DELETE" | "PATCH" | "ws" | "sse" ;
 
 ## 11. Design Principles
 
-1. **Intent over implementation**: Glyph describes what a service does, not how.
+1. **Intent over implementation**: GlyphLang describes what a service does, not how.
 2. **Provider abstraction**: Services depend on capabilities, not specific libraries.
 3. **Two syntaxes, one semantics**: Compact for AI, expanded for humans.
 4. **Verifiable**: The type system catches mismatches at analysis time.

--- a/docs/LANGUAGE_SPECIFICATION.md
+++ b/docs/LANGUAGE_SPECIFICATION.md
@@ -1,4 +1,4 @@
-# GlyphLang Language Specification
+# GlyphLang Specification
 
 Version 1.0
 

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -1,6 +1,6 @@
-# Glyph Performance Benchmarks
+# GlyphLang Performance Benchmarks
 
-This document contains performance benchmarks for the Glyph compiler and runtime, demonstrating compilation speed, bytecode efficiency, and VM execution performance.
+This document contains performance benchmarks for the GlyphLang compiler and runtime, demonstrating compilation speed, bytecode efficiency, and VM execution performance.
 
 ## System Information
 
@@ -183,12 +183,12 @@ go test ./tests -v -run=Benchmark
 
 | Tool | Compilation | Execution | Notes |
 |------|-------------|-----------|-------|
-| Glyph | < 1us | ~10ns/op | This project |
+| GlyphLang | < 1us | ~10ns/op | This project |
 | Python | N/A | ~100ns/op | Interpreted |
 | Node.js | ~10ms | ~50ns/op | JIT compiled |
 | Go | ~100ms | ~5ns/op | Native compiled |
 
-**Note**: Glyph provides near-native execution speed with instant compilation times.
+**Note**: GlyphLang provides near-native execution speed with instant compilation times.
 
 ---
 

--- a/docs/POLYGLOT_ROADMAP.md
+++ b/docs/POLYGLOT_ROADMAP.md
@@ -64,11 +64,11 @@ The Semantic IR, generalized provider system, and Python/FastAPI codegen are mer
 - [x] Compare results across the 5 intent-test scenarios
 - [x] Document findings
 
-**Results**: Glyph scored 9.93/10 avg vs 9.20/10 for natural language (checklist-validated, 3 independent evaluators). Largest advantage in structural precision (+1.0) and completeness (+0.8). See `tests/intent-hypothesis/RESULTS.md` for full analysis.
+**Results**: GlyphLang scored 9.93/10 avg vs 9.20/10 for natural language (checklist-validated, 3 independent evaluators). Largest advantage in structural precision (+1.0) and completeness (+0.8). See `tests/intent-hypothesis/RESULTS.md` for full analysis.
 
 ## Phase 6: Expand IR Coverage (complete)
 
-**Goal**: Handle all Glyph language features in the IR.
+**Goal**: Handle all GlyphLang language features in the IR.
 
 - [x] WebSocket details (connect/message/disconnect handlers, room management)
 - [x] GraphQL schema/resolver generation

--- a/docs/language-guide.md
+++ b/docs/language-guide.md
@@ -1,4 +1,4 @@
-# GlyphLang Language Guide
+# GlyphLang Guide
 
 ## Syntax Overview
 

--- a/editors/neovim/README.md
+++ b/editors/neovim/README.md
@@ -1,6 +1,6 @@
-# Neovim Support for Glyph
+# Neovim Support for GlyphLang
 
-This directory contains Neovim configuration files for Glyph syntax highlighting and LSP support.
+This directory contains Neovim configuration files for GlyphLang syntax highlighting and LSP support.
 
 ## Installation
 
@@ -106,7 +106,7 @@ The syntax file provides highlighting for:
 
 ### LSP Features
 
-When the Glyph LSP is configured:
+When the GlyphLang LSP is configured:
 - Go to definition (`gd`)
 - Find references (`gr`)
 - Hover documentation (`K`)

--- a/editors/neovim/ftdetect/glyph.vim
+++ b/editors/neovim/ftdetect/glyph.vim
@@ -1,3 +1,3 @@
-" Filetype detection for Glyph files
+" Filetype detection for GlyphLang files
 autocmd BufNewFile,BufRead *.glyph setfiletype glyph
 autocmd BufNewFile,BufRead *.glyphx setfiletype glyph

--- a/editors/neovim/ftplugin/glyph.vim
+++ b/editors/neovim/ftplugin/glyph.vim
@@ -1,5 +1,5 @@
-" Filetype plugin for Glyph files
-" Language: Glyph
+" Filetype plugin for GlyphLang files
+" Language: GlyphLang
 
 if exists("b:did_ftplugin")
   finish

--- a/editors/neovim/lsp.lua
+++ b/editors/neovim/lsp.lua
@@ -1,22 +1,22 @@
--- Glyph LSP Configuration for Neovim
+-- GlyphLang LSP Configuration for Neovim
 -- Add this to your Neovim configuration (init.lua or lua/plugins/lsp.lua)
 
 local M = {}
 
--- Setup function to configure Glyph LSP
+-- Setup function to configure GlyphLang LSP
 function M.setup(opts)
   opts = opts or {}
 
   -- Check if lspconfig is available
   local ok, lspconfig = pcall(require, 'lspconfig')
   if not ok then
-    vim.notify("nvim-lspconfig is required for Glyph LSP support", vim.log.levels.ERROR)
+    vim.notify("nvim-lspconfig is required for GlyphLang LSP support", vim.log.levels.ERROR)
     return
   end
 
   local configs = require('lspconfig.configs')
 
-  -- Register Glyph LSP if not already registered
+  -- Register GlyphLang LSP if not already registered
   if not configs.glyph then
     configs.glyph = {
       default_config = {

--- a/editors/neovim/queries/glyph/highlights.scm
+++ b/editors/neovim/queries/glyph/highlights.scm
@@ -1,4 +1,4 @@
-; Glyph Tree-sitter Highlights
+; GlyphLang Tree-sitter Highlights
 ; Note: This file is for future tree-sitter integration
 ; Currently, use the vim syntax file for highlighting
 

--- a/editors/neovim/queries/glyph/indents.scm
+++ b/editors/neovim/queries/glyph/indents.scm
@@ -1,4 +1,4 @@
-; Glyph Tree-sitter Indentation Queries
+; GlyphLang Tree-sitter Indentation Queries
 
 ; Indent after opening braces
 [

--- a/editors/neovim/syntax/glyph.vim
+++ b/editors/neovim/syntax/glyph.vim
@@ -1,5 +1,5 @@
 " Vim syntax file
-" Language: Glyph
+" Language: GlyphLang
 " Maintainer: GlyphLang Team
 " Latest Revision: 2024
 

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -1,6 +1,6 @@
 # GlyphLang VS Code Extension
 
-Syntax highlighting and language support for Glyph (`.glyph`) and expanded Glyph (`.glyphx`) files.
+Syntax highlighting and language support for GlyphLang (`.glyph`) and expanded GlyphLang (`.glyphx`) files.
 
 ## Features
 
@@ -49,7 +49,7 @@ The `.glyphx` format uses human-readable keywords instead of symbols:
 
 ### LSP Setup
 
-The extension uses the Glyph CLI's built-in language server. Ensure `glyph` is in your PATH:
+The extension uses the GlyphLang CLI's built-in language server. Ensure `glyph` is in your PATH:
 
 ```bash
 go install github.com/glyphlang/glyph/cmd/glyph@latest
@@ -61,12 +61,12 @@ The LSP server is started automatically when opening `.glyph` or `.glyphx` files
 
 | Setting                    | Default  | Description                              |
 |----------------------------|----------|------------------------------------------|
-| `glyph.lsp.enabled`       | `true`   | Enable the Glyph Language Server         |
+| `glyph.lsp.enabled`       | `true`   | Enable the GlyphLang Language Server         |
 | `glyph.lsp.path`          | `glyph`  | Path to the glyph CLI binary             |
 | `glyph.autoExpandOnOpen`  | `false`  | Auto-expand .glyph to .glyphx on open    |
 | `glyph.autoCompactOnSave` | `false`  | Auto-compact .glyphx to .glyph on save   |
 
 ## Commands
 
-- **Glyph: Expand to .glyphx** - Convert current `.glyph` file to expanded syntax
-- **Glyph: Compact to .glyph** - Convert current `.glyphx` file to compact syntax
+- **GlyphLang: Expand to .glyphx** - Convert current `.glyph` file to expanded syntax
+- **GlyphLang: Compact to .glyph** - Convert current `.glyphx` file to compact syntax

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -1,7 +1,7 @@
 {
   "name": "glyphlang",
   "displayName": "GlyphLang",
-  "description": "Syntax highlighting and language support for Glyph (.glyph) and expanded Glyph (.glyphx) files",
+  "description": "Syntax highlighting and language support for GlyphLang (.glyph) and expanded GlyphLang (.glyphx) files",
   "version": "0.2.0",
   "publisher": "GlyphLang",
   "engines": {
@@ -18,13 +18,13 @@
     "languages": [
       {
         "id": "glyph",
-        "aliases": ["Glyph", "glyph"],
+        "aliases": ["GlyphLang", "Glyph", "glyph"],
         "extensions": [".glyph"],
         "configuration": "./language-configuration.json"
       },
       {
         "id": "glyphx",
-        "aliases": ["GlyphX", "glyphx", "Glyph Expanded"],
+        "aliases": ["GlyphX", "glyphx", "GlyphLang Expanded"],
         "extensions": [".glyphx"],
         "configuration": "./language-configuration.json"
       }
@@ -47,7 +47,7 @@
         "glyph.lsp.enabled": {
           "type": "boolean",
           "default": true,
-          "description": "Enable the Glyph Language Server"
+          "description": "Enable the GlyphLang Language Server"
         },
         "glyph.lsp.path": {
           "type": "string",
@@ -69,11 +69,11 @@
     "commands": [
       {
         "command": "glyph.expandToGlyphx",
-        "title": "Glyph: Expand to .glyphx"
+        "title": "GlyphLang: Expand to .glyphx"
       },
       {
         "command": "glyph.compactToGlyph",
-        "title": "Glyph: Compact to .glyph"
+        "title": "GlyphLang: Compact to .glyph"
       }
     ]
   }

--- a/editors/vscode/syntaxes/glyph.tmLanguage.json
+++ b/editors/vscode/syntaxes/glyph.tmLanguage.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
-  "name": "Glyph",
+  "name": "GlyphLang",
   "scopeName": "source.glyph",
   "patterns": [
     { "include": "#comments" },

--- a/examples/blog-api-complete/README.md
+++ b/examples/blog-api-complete/README.md
@@ -1,6 +1,6 @@
 # Blog API - Complete Example
 
-A full-featured blog API demonstrating Glyph's capabilities.
+A full-featured blog API demonstrating GlyphLang's capabilities.
 
 ## Features
 
@@ -103,7 +103,7 @@ curl "http://localhost:3000/search?query=database&category=tutorial"
   "posts": [
     {
       "id": 1,
-      "title": "Getting Started with Glyph",
+      "title": "Getting Started with GlyphLang",
       "slug": "getting-started-with-glyph",
       "excerpt": "Learn the basics...",
       "author": "Alice Johnson",

--- a/examples/blog-api-complete/main.glyph
+++ b/examples/blog-api-complete/main.glyph
@@ -42,10 +42,10 @@
   $ all_posts = [
     {
       :id = 1,
-      :title = "Getting Started with Glyph",
+      :title = "Getting Started with GlyphLang",
       :slug = "getting-started-with-glyph",
-      :content = "Glyph is a revolutionary backend language designed for AI-generated code. With sub-microsecond compilation times and built-in security scanning, it's the perfect choice for modern backends.",
-      :excerpt = "Learn the basics of Glyph in this comprehensive guide.",
+      :content = "GlyphLang is a revolutionary backend language designed for AI-generated code. With sub-microsecond compilation times and built-in security scanning, it's the perfect choice for modern backends.",
+      :excerpt = "Learn the basics of GlyphLang in this comprehensive guide.",
       :author = "Alice Johnson",
       :author_id = 1,
       :category = "Tutorial",
@@ -61,10 +61,10 @@
     },
     {
       :id = 2,
-      :title = "Building REST APIs with Glyph",
+      :title = "Building REST APIs with GlyphLang",
       :slug = "building-rest-apis",
-      :content = "Learn how to build production-ready REST APIs using Glyph. We'll cover routing, validation, error handling, and best practices.",
-      :excerpt = "Master REST API development with Glyph.",
+      :content = "Learn how to build production-ready REST APIs using GlyphLang. We'll cover routing, validation, error handling, and best practices.",
+      :excerpt = "Master REST API development with GlyphLang.",
       :author = "Bob Smith",
       :author_id = 2,
       :category = "Tutorial",
@@ -80,10 +80,10 @@
     },
     {
       :id = 3,
-      :title = "Advanced Glyph Patterns",
+      :title = "Advanced GlyphLang Patterns",
       :slug = "advanced-glyph-patterns",
-      :content = "Dive deep into advanced patterns, optimization techniques, and architectural best practices for Glyph applications.",
-      :excerpt = "Take your Glyph skills to the next level.",
+      :content = "Dive deep into advanced patterns, optimization techniques, and architectural best practices for GlyphLang applications.",
+      :excerpt = "Take your GlyphLang skills to the next level.",
       :author = "Charlie Davis",
       :author_id = 3,
       :category = "Advanced",
@@ -101,8 +101,8 @@
       :id = 4,
       :title = "Database Integration Guide",
       :slug = "database-integration",
-      :content = "Connect your Glyph application to PostgreSQL, MySQL, or MongoDB. Learn about connection pooling, transactions, and ORMs.",
-      :excerpt = "Master database integration in Glyph.",
+      :content = "Connect your GlyphLang application to PostgreSQL, MySQL, or MongoDB. Learn about connection pooling, transactions, and ORMs.",
+      :excerpt = "Master database integration in GlyphLang.",
       :author = "Alice Johnson",
       :author_id = 1,
       :category = "Tutorial",
@@ -120,8 +120,8 @@
       :id = 5,
       :title = "Real-time Features with WebSockets",
       :slug = "websockets-guide",
-      :content = "Build real-time applications using Glyph's WebSocket support. Create chat apps, live notifications, and collaborative tools.",
-      :excerpt = "Add real-time capabilities to your Glyph apps.",
+      :content = "Build real-time applications using GlyphLang's WebSocket support. Create chat apps, live notifications, and collaborative tools.",
+      :excerpt = "Add real-time capabilities to your GlyphLang apps.",
       :author = "Bob Smith",
       :author_id = 2,
       :category = "Tutorial",
@@ -382,7 +382,7 @@
   ? validate_length(query, 1, 100)
 
   $ results = [
-    {:id = 1, :title = "Getting Started with Glyph", :excerpt = "Learn Glyph basics...", :score = 0.95},
+    {:id = 1, :title = "Getting Started with GlyphLang", :excerpt = "Learn GlyphLang basics...", :score = 0.95},
     {:id = 4, :title = "Database Integration Guide", :excerpt = "Connect to databases...", :score = 0.87}
   ]
 

--- a/examples/blog-api/README.md
+++ b/examples/blog-api/README.md
@@ -252,8 +252,8 @@ Increments the upvote count for a comment. Requires authentication.
    ```
    POST /api/posts
    {
-     "title": "Getting Started with Glyph",
-     "content": "Glyph is a language for building APIs...",
+     "title": "Getting Started with GlyphLang",
+     "content": "GlyphLang is a language for building APIs...",
      "tags": ["tutorial", "beginner"]
    }
    ```

--- a/examples/comprehensive-demo/main.glyph
+++ b/examples/comprehensive-demo/main.glyph
@@ -1,4 +1,4 @@
-# Comprehensive Glyph Demo
+# Comprehensive GlyphLang Demo
 # Showcasing all language features
 
 : User {

--- a/examples/expand-demo/main.glyph
+++ b/examples/expand-demo/main.glyph
@@ -9,7 +9,7 @@
 # Simple hello endpoint
 @ GET / {
   > {
-    message: "Welcome to Glyph!",
+    message: "Welcome to GlyphLang!",
     version: "1.0.0"
   }
 }

--- a/examples/expand-demo/seed.json
+++ b/examples/expand-demo/seed.json
@@ -1,6 +1,6 @@
 {
   "tasks": [
-    {"id": 1, "title": "Learn Glyph", "completed": false, "priority": 1},
+    {"id": 1, "title": "Learn GlyphLang", "completed": false, "priority": 1},
     {"id": 2, "title": "Build an API", "completed": false, "priority": 2},
     {"id": 3, "title": "Test expand/compact", "completed": true, "priority": 1}
   ]

--- a/examples/for-loop-demo.glyph
+++ b/examples/for-loop-demo.glyph
@@ -1,4 +1,4 @@
-# For Loop Examples in Glyph
+# For Loop Examples in GlyphLang
 
 # Example 1: Simple array iteration
 @ GET /users {

--- a/examples/function-call-demo.glyph
+++ b/examples/function-call-demo.glyph
@@ -1,4 +1,4 @@
-# Function Call Examples in Glyph
+# Function Call Examples in GlyphLang
 
 # Example 1: Get current timestamp
 @ GET /time {

--- a/examples/generated-output-README.md
+++ b/examples/generated-output-README.md
@@ -29,7 +29,7 @@ examples/<name>/
 
 ## Regenerating
 
-To regenerate these files, build the Glyph compiler and run:
+To regenerate these files, build the GlyphLang compiler and run:
 
 ```bash
 go build -o glyph ./cmd/glyph

--- a/examples/intent-tests/05-auth-service.glyph
+++ b/examples/intent-tests/05-auth-service.glyph
@@ -1,7 +1,7 @@
 # Intent Test: Authentication service with registration, login, and token management
 # NOTE: This is a DSL syntax demonstration for polyglot code generation testing.
 # Actual security (bcrypt hashing, JWT signing, HTTPS) is implemented by target
-# language backends. Glyph DSL functions like crypto.hash() and jwt.sign() map
+# language backends. GlyphLang DSL functions like crypto.hash() and jwt.sign() map
 # to secure implementations in each target (e.g., bcrypt in Go, passlib in Python).
 
 : User {

--- a/examples/lsp-demo/demo.glyph
+++ b/examples/lsp-demo/demo.glyph
@@ -1,4 +1,4 @@
-# Glyph LSP Demo
+# GlyphLang LSP Demo
 # This file demonstrates LSP features
 
 # Type Definition - Hover over "User" to see type info

--- a/examples/rest-api/main.glyph
+++ b/examples/rest-api/main.glyph
@@ -1,4 +1,4 @@
-# Example REST API in Glyph
+# Example REST API in GlyphLang
 # This demonstrates the basic syntax and features
 
 # Define a User type

--- a/examples/server-demo/CURL_EXAMPLES.md
+++ b/examples/server-demo/CURL_EXAMPLES.md
@@ -1,6 +1,6 @@
-# Glyph Server - curl Examples
+# GlyphLang Server - curl Examples
 
-Quick reference for testing the Glyph HTTP server with curl commands.
+Quick reference for testing the GlyphLang HTTP server with curl commands.
 
 ## Prerequisites
 

--- a/examples/server-demo/main.go
+++ b/examples/server-demo/main.go
@@ -32,7 +32,7 @@ func main() {
 		server.WithInterpreter(&demoInterpreter{
 			Response: map[string]interface{}{
 				"status": "ok",
-				"server": "Glyph Demo Server",
+				"server": "GlyphLang Demo Server",
 			},
 		}),
 	)
@@ -214,7 +214,7 @@ func main() {
 
 	// Start server in goroutine
 	go func() {
-		log.Printf("Starting Glyph Demo Server on http://localhost:8080")
+		log.Printf("Starting GlyphLang Demo Server on http://localhost:8080")
 		log.Println("\nAvailable endpoints:")
 		log.Println("  GET    /hello")
 		log.Println("  GET    /greet/:name")

--- a/examples/server-demo/test-endpoints.bat
+++ b/examples/server-demo/test-endpoints.bat
@@ -1,8 +1,8 @@
 @echo off
-REM Test script for Glyph Demo Server (Windows)
+REM Test script for GlyphLang Demo Server (Windows)
 REM Make sure the server is running before executing this script
 
-echo Testing Glyph Demo Server Endpoints
+echo Testing GlyphLang Demo Server Endpoints
 echo ====================================
 echo.
 

--- a/examples/server-demo/test-endpoints.sh
+++ b/examples/server-demo/test-endpoints.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
-# Test script for Glyph Demo Server
+# Test script for GlyphLang Demo Server
 # Make sure the server is running before executing this script
 
-echo "Testing Glyph Demo Server Endpoints"
+echo "Testing GlyphLang Demo Server Endpoints"
 echo "===================================="
 echo ""
 

--- a/examples/todo-api/README.md
+++ b/examples/todo-api/README.md
@@ -1,6 +1,6 @@
 # Todo List API
 
-A comprehensive todo list API demonstrating CRUD operations in Glyph.
+A comprehensive todo list API demonstrating CRUD operations in GlyphLang.
 
 ## Features
 
@@ -41,7 +41,7 @@ Returns a specific todo by its ID.
 {
   "id": 1,
   "title": "Complete project",
-  "description": "Finish the Glyph implementation",
+  "description": "Finish the GlyphLang implementation",
   "completed": false,
   "priority": "high",
   "created_at": 1234567890,

--- a/examples/websocket-chat/index.html
+++ b/examples/websocket-chat/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Glyph WebSocket Chat</title>
+    <title>GlyphLang WebSocket Chat</title>
     <style>
         * {
             margin: 0;
@@ -234,7 +234,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <h1>Glyph WebSocket Chat</h1>
+            <h1>GlyphLang WebSocket Chat</h1>
             <div class="status" id="status">Disconnected</div>
         </div>
 

--- a/examples/while-loop-demo.glyph
+++ b/examples/while-loop-demo.glyph
@@ -1,4 +1,4 @@
-# Glyph While Loop Demonstration
+# GlyphLang While Loop Demonstration
 # This file demonstrates the while loop feature
 
 # Example 1: Simple counter

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -126,7 +126,9 @@ setup_path() {
     fi
 
     if [ -n "$PROFILE" ] && [ -f "$PROFILE" ]; then
-        # Check if export already exists
+        # Check if export already exists. Match on "Glyph" rather than "GlyphLang"
+        # so profiles written by older installers (marker "# Glyph") are still
+        # detected and we do not append a duplicate PATH entry.
         if grep -q "Glyph" "$PROFILE" 2>/dev/null; then
             info "PATH entry already exists in $PROFILE"
         else

--- a/llms.txt
+++ b/llms.txt
@@ -4,6 +4,9 @@
 
 Deploy target: https://glyphlang.dev/llms.txt
 Source of truth: docs/GLYPH_NOTATION_SPEC.md in https://github.com/GlyphLang/GlyphLang (regenerate this file when the spec changes: make llms.txt)
+GlyphLang is symbol notation: every declaration begins with a glyph at the start of a line, and
+there are no keyword declaration forms. It runs `.glyph` sources directly on a single static
+binary — install from GitHub Releases (https://github.com/GlyphLang/GlyphLang/releases).
 
 ## Quick example
 
@@ -33,16 +36,16 @@ Source of truth: docs/GLYPH_NOTATION_SPEC.md in https://github.com/GlyphLang/Gly
 
 ---
 
-# Glyph Notation Specification
+# GlyphLang Notation Specification
 
 **Version:** 0.1.0-draft
 **Status:** Working draft
 
 ## 1. Overview
 
-Glyph notation is a compact, typed, language-neutral notation for describing backend services. It is designed to be consumed by both humans and AI systems, and can be compiled, interpreted, or used as a structured intent language for code generation in any target language.
+GlyphLang notation is a compact, typed, language-neutral notation for describing backend services. It is designed to be consumed by both humans and AI systems, and can be compiled, interpreted, or used as a structured intent language for code generation in any target language.
 
-A Glyph program describes **what a service does**, not how it does it in any specific language.
+A GlyphLang program describes **what a service does**, not how it does it in any specific language.
 
 ## 2. Symbol Vocabulary
 
@@ -111,8 +114,8 @@ Fields marked with `!` are required. Fields marked with `?` are optional. Fields
 
 ### 3.4 Target Language Type Mapping
 
-| Glyph | Python | TypeScript | Go | Java | Rust |
-|-------|--------|------------|-----|------|------|
+| GlyphLang | Python | TypeScript | Go | Java | Rust |
+|-----------|--------|------------|-----|------|------|
 | `int` | `int` | `number` | `int64` | `long` | `i64` |
 | `float` | `float` | `number` | `float64` | `double` | `f64` |
 | `str` | `str` | `string` | `string` | `String` | `String` |
@@ -271,7 +274,7 @@ respond `200`.
 
 ## 7. Semantic IR
 
-The Semantic IR is the language-neutral intermediate representation produced by analyzing a Glyph program. It captures intent independent of any target language.
+The Semantic IR is the language-neutral intermediate representation produced by analyzing a GlyphLang program. It captures intent independent of any target language.
 
 ### 7.1 IR Structure
 
@@ -318,7 +321,7 @@ All expressions are normalized into a flat, discriminated union:
 
 ## 8. Compact vs Expanded Syntax
 
-Every Glyph program has two equivalent representations:
+Every GlyphLang program has two equivalent representations:
 
 **Compact** (`.glyph`): Uses symbols for maximum token efficiency
 ```
@@ -394,7 +397,7 @@ method      = "GET" | "POST" | "PUT" | "DELETE" | "PATCH" | "ws" | "sse" ;
 
 ## 11. Design Principles
 
-1. **Intent over implementation**: Glyph describes what a service does, not how.
+1. **Intent over implementation**: GlyphLang describes what a service does, not how.
 2. **Provider abstraction**: Services depend on capabilities, not specific libraries.
 3. **Two syntaxes, one semantics**: Compact for AI, expanded for humans.
 4. **Verifiable**: The type system catches mismatches at analysis time.

--- a/pkg/codegen/python.go
+++ b/pkg/codegen/python.go
@@ -409,7 +409,7 @@ func (g *PythonGenerator) writeExpr(sb *strings.Builder, expr ir.ExprIR) {
 		g.writeExpr(sb, expr.IndexAccess.Index)
 		sb.WriteString("]")
 	case ir.ExprCall:
-		// The Glyph parser converts method calls (obj.method(args)) into function
+		// The GlyphLang parser converts method calls (obj.method(args)) into function
 		// calls where the object is the first argument. Detect this pattern and
 		// render as a method call: if the first arg is a field access or variable
 		// and the function name is simple (no dots), it's a method call.

--- a/pkg/codegen/typescript_server.go
+++ b/pkg/codegen/typescript_server.go
@@ -1001,7 +1001,7 @@ func irTypeToTypeScript(t ir.TypeRef) string {
 }
 
 func glyphPathToExpress(path string) string {
-	// Express uses :param syntax (same as Glyph), so no conversion needed
+	// Express uses :param syntax (same as GlyphLang), so no conversion needed
 	return path
 }
 

--- a/pkg/compiler/websocket.go
+++ b/pkg/compiler/websocket.go
@@ -333,7 +333,7 @@ func (c *Compiler) CompileModule(module *ast.Module) (*CompiledModule, error) {
 	return result, nil
 }
 
-// CompiledModule represents a fully compiled Glyph module
+// CompiledModule represents a fully compiled GlyphLang module
 type CompiledModule struct {
 	Routes          map[string][]byte                  // HTTP routes: "METHOD /path" -> bytecode
 	WebSocketRoutes map[string]*CompiledWebSocketRoute // WS routes: "/path" -> compiled handlers

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -1,5 +1,5 @@
-// Package context provides AI-optimized context generation for Glyph projects.
-// This enables AI agents to efficiently understand and work with Glyph codebases
+// Package context provides AI-optimized context generation for GlyphLang projects.
+// This enables AI agents to efficiently understand and work with GlyphLang codebases
 // by providing compact, cacheable representations of project structure.
 package context
 
@@ -18,7 +18,7 @@ import (
 	"github.com/glyphlang/glyph/pkg/parser"
 )
 
-// ProjectContext represents the complete AI-optimized context for a Glyph project
+// ProjectContext represents the complete AI-optimized context for a GlyphLang project
 type ProjectContext struct {
 	Version     string                   `json:"version"`
 	Generated   time.Time                `json:"generated"`
@@ -76,7 +76,7 @@ type CommandInfo struct {
 	Hash        string   `json:"hash"`
 }
 
-// Generator generates AI context from Glyph source files
+// Generator generates AI context from GlyphLang source files
 type Generator struct {
 	rootDir string
 }
@@ -184,7 +184,7 @@ func (g *Generator) findGlyphFiles() ([]string, error) {
 	return files, err
 }
 
-// processFile processes a single Glyph file and extracts context
+// processFile processes a single GlyphLang file and extracts context
 func (g *Generator) processFile(relPath string, ctx *ProjectContext) (*FileContext, error) {
 	fullPath := filepath.Join(g.rootDir, relPath)
 
@@ -548,7 +548,7 @@ func (ctx *ProjectContext) ToJSON(pretty bool) ([]byte, error) {
 func (ctx *ProjectContext) ToCompact() string {
 	var sb strings.Builder
 
-	sb.WriteString("# Glyph Project Context\n")
+	sb.WriteString("# GlyphLang Project Context\n")
 	sb.WriteString(fmt.Sprintf("# Hash: %s\n\n", ctx.ProjectHash[:12]))
 
 	// Types section (sorted for deterministic output)
@@ -946,7 +946,7 @@ func (d *ContextDiff) ToJSON(pretty bool) ([]byte, error) {
 func (d *ContextDiff) ToCompact(ctx *ProjectContext) string {
 	var sb strings.Builder
 
-	sb.WriteString("# Glyph Context Changes\n")
+	sb.WriteString("# GlyphLang Context Changes\n")
 	sb.WriteString(fmt.Sprintf("# Previous: %s\n", truncateHash(d.PreviousHash)))
 	sb.WriteString(fmt.Sprintf("# Current:  %s\n\n", truncateHash(d.CurrentHash)))
 
@@ -1072,7 +1072,7 @@ type TargetedContext struct {
 	Syntax      *SyntaxGuide             `json:"syntax,omitempty"`
 }
 
-// SyntaxGuide provides quick reference for Glyph syntax
+// SyntaxGuide provides quick reference for GlyphLang syntax
 type SyntaxGuide struct {
 	Examples []string `json:"examples"`
 	Notes    []string `json:"notes,omitempty"`
@@ -1229,7 +1229,7 @@ func (tc *TargetedContext) ToJSON(pretty bool) ([]byte, error) {
 func (tc *TargetedContext) ToCompact() string {
 	var sb strings.Builder
 
-	sb.WriteString(fmt.Sprintf("# Glyph Context: %s\n", tc.Task))
+	sb.WriteString(fmt.Sprintf("# GlyphLang Context: %s\n", tc.Task))
 	sb.WriteString(fmt.Sprintf("# %s\n\n", tc.Description))
 
 	// Syntax guide first (most important for AI)
@@ -1334,7 +1334,7 @@ func (tc *TargetedContext) ToCompact() string {
 func (ctx *ProjectContext) GenerateStubs() string {
 	var sb strings.Builder
 
-	sb.WriteString("# Auto-generated Glyph type stubs\n")
+	sb.WriteString("# Auto-generated GlyphLang type stubs\n")
 	sb.WriteString(fmt.Sprintf("# Generated: %s\n", ctx.Generated.Format(time.RFC3339)))
 	sb.WriteString(fmt.Sprintf("# Hash: %s\n\n", ctx.ProjectHash[:12]))
 

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -76,7 +76,7 @@ type CommandInfo struct {
 	Hash        string   `json:"hash"`
 }
 
-// Generator generates AI context from GlyphLang source files
+// Generator generates AI context from .glyph source files
 type Generator struct {
 	rootDir string
 }
@@ -184,7 +184,7 @@ func (g *Generator) findGlyphFiles() ([]string, error) {
 	return files, err
 }
 
-// processFile processes a single GlyphLang file and extracts context
+// processFile processes a single .glyph file and extracts context
 func (g *Generator) processFile(relPath string, ctx *ProjectContext) (*FileContext, error) {
 	fullPath := filepath.Join(g.rootDir, relPath)
 

--- a/pkg/context/context_test.go
+++ b/pkg/context/context_test.go
@@ -358,7 +358,7 @@ func TestProjectContextToCompact(t *testing.T) {
 	compact := ctx.ToCompact()
 
 	// Verify sections are present
-	if !strings.Contains(compact, "# Glyph Project Context") {
+	if !strings.Contains(compact, "# GlyphLang Project Context") {
 		t.Error("missing header")
 	}
 	if !strings.Contains(compact, "## Types") {
@@ -539,7 +539,7 @@ func TestContextDiffToCompact(t *testing.T) {
 
 	compact := diff.ToCompact(ctx)
 
-	if !strings.Contains(compact, "# Glyph Context Changes") {
+	if !strings.Contains(compact, "# GlyphLang Context Changes") {
 		t.Error("missing header")
 	}
 	if !strings.Contains(compact, "+ new.glyph") {
@@ -698,7 +698,7 @@ func TestTargetedContextToCompact(t *testing.T) {
 
 	compact := tc.ToCompact()
 
-	if !strings.Contains(compact, "# Glyph Context: route") {
+	if !strings.Contains(compact, "# GlyphLang Context: route") {
 		t.Error("missing header")
 	}
 	if !strings.Contains(compact, "## Syntax") {
@@ -729,7 +729,7 @@ func TestGenerateStubs(t *testing.T) {
 
 	stubs := ctx.GenerateStubs()
 
-	if !strings.Contains(stubs, "# Auto-generated Glyph type stubs") {
+	if !strings.Contains(stubs, "# Auto-generated GlyphLang type stubs") {
 		t.Error("missing header")
 	}
 	if !strings.Contains(stubs, ": User") {

--- a/pkg/database/QUICK_START.md
+++ b/pkg/database/QUICK_START.md
@@ -40,7 +40,7 @@ defer db.Close()
 ### 3. Use in Go Code
 
 ```go
-// Create handler for Glyph integration
+// Create handler for GlyphLang integration
 handler := database.NewHandler(db)
 
 // Or use ORM directly
@@ -71,7 +71,7 @@ users, err := orm.NewQueryBuilder().
     Get(ctx)
 ```
 
-### 4. Use in Glyph Code
+### 4. Use in GlyphLang Code
 
 Create a route with database injection:
 

--- a/pkg/database/README.md
+++ b/pkg/database/README.md
@@ -1,6 +1,6 @@
-# Glyph Database Package
+# GlyphLang Database Package
 
-Complete database integration layer for Glyph with PostgreSQL driver and ORM capabilities.
+Complete database integration layer for GlyphLang with PostgreSQL driver and ORM capabilities.
 
 ## Features
 
@@ -76,7 +76,7 @@ users, err := orm.NewQueryBuilder().
     Get(ctx)
 ```
 
-### Using the Handler (for Glyph integration)
+### Using the Handler (for GlyphLang integration)
 
 ```go
 // Create handler
@@ -94,9 +94,9 @@ err := users.Delete(1)
 count, err := users.Count("status", "active")
 ```
 
-## Glyph Language Integration
+## GlyphLang Integration
 
-In your Glyph code, inject the database using `% db: Database`:
+In your GlyphLang code, inject the database using `% db: Database`:
 
 ```glyph
 @ route /api/users/:id [GET] -> User
@@ -339,4 +339,4 @@ See `examples/database-demo/main.glyph` for a complete CRUD application example.
 
 ## License
 
-Part of the Glyph project.
+Part of the GlyphLang project.

--- a/pkg/database/handler.go
+++ b/pkg/database/handler.go
@@ -62,7 +62,7 @@ func (h *Handler) Close() error {
 	return h.db.Close()
 }
 
-// TableHandler provides high-level database operations for GLYPH
+// TableHandler provides high-level database operations for GlyphLang
 type TableHandler struct {
 	db   Database
 	orm  *ORM

--- a/pkg/debug/repl.go
+++ b/pkg/debug/repl.go
@@ -63,7 +63,7 @@ func (r *REPL) Stop() {
 
 // printWelcome prints the welcome message
 func (r *REPL) printWelcome() {
-	r.printf("Glyph Debugger REPL\n")
+	r.printf("GlyphLang Debugger REPL\n")
 	r.printf("Type 'help' for available commands\n")
 	r.printf("=====================================\n\n")
 }

--- a/pkg/formatter/formatter.go
+++ b/pkg/formatter/formatter.go
@@ -1,7 +1,7 @@
 // Package formatter provides bidirectional conversion between compact glyph syntax
 // and expanded human-readable syntax.
 //
-// Compact (Glyph) syntax uses symbols:
+// Compact (glyph) syntax uses symbols:
 //
 //	: -> type definition
 //	@ -> route

--- a/pkg/graphql/executor.go
+++ b/pkg/graphql/executor.go
@@ -6,7 +6,7 @@ import (
 	"github.com/glyphlang/glyph/pkg/interpreter"
 )
 
-// Executor handles GraphQL query execution against a schema using the Glyph interpreter.
+// Executor handles GraphQL query execution against a schema using the GlyphLang interpreter.
 type Executor struct {
 	schema *Schema
 	interp *interpreter.Interpreter

--- a/pkg/graphql/graphql_test.go
+++ b/pkg/graphql/graphql_test.go
@@ -261,7 +261,7 @@ func TestGenerateSDL(t *testing.T) {
 	assert.Contains(t, sdl, "user(id: Int!): User")
 }
 
-// TestTypeToGraphQL verifies Glyph type to GraphQL type conversion
+// TestTypeToGraphQL verifies GlyphLang type to GraphQL type conversion
 func TestTypeToGraphQL(t *testing.T) {
 	tests := []struct {
 		input    ast.Type

--- a/pkg/graphql/schema.go
+++ b/pkg/graphql/schema.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 )
 
-// Schema represents a GraphQL schema built from Glyph type definitions and resolvers.
+// Schema represents a GraphQL schema built from GlyphLang type definitions and resolvers.
 type Schema struct {
 	Types     map[string]*ObjectType
 	Query     *ObjectType
@@ -44,7 +44,7 @@ func BuildSchema(typeDefs map[string]ast.TypeDef, resolvers map[string]ast.Graph
 		Resolvers: resolvers,
 	}
 
-	// Convert Glyph type definitions to GraphQL object types
+	// Convert GlyphLang type definitions to GraphQL object types
 	for name, td := range typeDefs {
 		objType := &ObjectType{
 			Name:   name,

--- a/pkg/grpc/grpc_test.go
+++ b/pkg/grpc/grpc_test.go
@@ -93,7 +93,7 @@ func TestGenerateProtoWithStreaming(t *testing.T) {
 	assert.Contains(t, output, "rpc Chat (stream Message) returns (stream Message)")
 }
 
-// TestGenerateProtoFieldTypes verifies type mapping from Glyph to proto types
+// TestGenerateProtoFieldTypes verifies type mapping from GlyphLang to proto types
 func TestGenerateProtoFieldTypes(t *testing.T) {
 	typeDefs := map[string]ast.TypeDef{
 		"Item": {

--- a/pkg/grpc/proto.go
+++ b/pkg/grpc/proto.go
@@ -42,7 +42,7 @@ type ProtoField struct {
 	Repeated bool
 }
 
-// GenerateProto generates a .proto file from Glyph service definitions and type definitions.
+// GenerateProto generates a .proto file from GlyphLang service definitions and type definitions.
 func GenerateProto(packageName string, services map[string]ast.GRPCService, typeDefs map[string]ast.TypeDef) *ProtoFile {
 	proto := &ProtoFile{
 		Package: packageName,

--- a/pkg/hotreload/watcher.go
+++ b/pkg/hotreload/watcher.go
@@ -351,7 +351,7 @@ func (w *FileWatcher) hashFile(path string) (string, error) {
 // Hot Reload Manager
 // ========================================
 
-// ReloadManager manages hot-reloading of Glyph applications
+// ReloadManager manages hot-reloading of GlyphLang applications
 type ReloadManager struct {
 	mu           sync.RWMutex
 	watcher      *FileWatcher
@@ -364,12 +364,12 @@ type ReloadManager struct {
 	onReload     func(ReloadEvent)
 }
 
-// CompilerInterface defines the interface for the Glyph compiler
+// CompilerInterface defines the interface for the GlyphLang compiler
 type CompilerInterface interface {
 	CompileFile(path string) ([]byte, error)
 }
 
-// ServerInterface defines the interface for the Glyph server
+// ServerInterface defines the interface for the GlyphLang server
 type ServerInterface interface {
 	Reload(bytecode []byte) error
 	GetState() map[string]interface{}

--- a/pkg/httpclient/handler.go
+++ b/pkg/httpclient/handler.go
@@ -168,7 +168,7 @@ func validateURL(rawURL string) error {
 	return nil
 }
 
-// doRequest executes an HTTP request and returns the response as a Glyph-friendly map.
+// doRequest executes an HTTP request and returns the response as a GlyphLang-friendly map.
 func (h *Handler) doRequest(method, reqURL string, opts *requestOptions) (map[string]interface{}, error) {
 	// Append query parameters
 	if len(opts.Query) > 0 {

--- a/pkg/interpreter/IMPLEMENTATION_REPORT.md
+++ b/pkg/interpreter/IMPLEMENTATION_REPORT.md
@@ -6,14 +6,14 @@
 
 ## Summary
 
-Successfully implemented a fully functional AST interpreter for the Glyph language in Go. The interpreter can execute Glyph routes, evaluate expressions, manage variable scopes, and handle user-defined functions.
+Successfully implemented a fully functional AST interpreter for the GlyphLang language in Go. The interpreter can execute GlyphLang routes, evaluate expressions, manage variable scopes, and handle user-defined functions.
 
 ## Files Created
 
 ### Core Implementation (5 files)
 
 1. **`ast.go`** (4,245 bytes)
-   - Complete AST type definitions for the Glyph language
+   - Complete AST type definitions for the GlyphLang language
    - Includes: Module, Item, TypeDef, Route, Function, Statement, Expression, Literal, BinOp types
    - Interface-based design for type safety
 
@@ -257,7 +257,7 @@ fn add(a: int, b: int) -> int:
 
 ### Parser Integration
 The interpreter expects AST nodes as defined in `ast.go`. The parser should:
-- Convert Glyph source code to these AST structures
+- Convert GlyphLang source code to these AST structures
 - Validate syntax and basic type correctness
 - Handle operator precedence
 
@@ -347,7 +347,7 @@ The AST interpreter is **fully functional** and ready for integration with the p
 - Conditional statements
 - Variable scoping
 
-All core features are implemented and tested. The interpreter provides a solid foundation for executing Glyph programs and can be extended as the language evolves.
+All core features are implemented and tested. The interpreter provides a solid foundation for executing GlyphLang programs and can be extended as the language evolves.
 
 ## Next Steps
 

--- a/pkg/interpreter/QUICKSTART.md
+++ b/pkg/interpreter/QUICKSTART.md
@@ -419,7 +419,7 @@ json.Marshal(response.Body)
 
 ## FAQ
 
-**Q: Can I execute Glyph source code directly?**
+**Q: Can I execute GlyphLang source code directly?**
 A: No, you need to parse it to AST first. This interpreter works with AST nodes.
 
 **Q: Is the interpreter thread-safe?**

--- a/pkg/interpreter/README.md
+++ b/pkg/interpreter/README.md
@@ -1,10 +1,10 @@
-# Glyph Interpreter
+# GlyphLang Interpreter
 
-A Go-based AST interpreter for the Glyph language.
+A Go-based AST interpreter for the GlyphLang language.
 
 ## Overview
 
-This interpreter executes Glyph AST nodes directly without compilation to bytecode. It supports:
+This interpreter executes GlyphLang AST nodes directly without compilation to bytecode. It supports:
 
 - Expression evaluation (literals, variables, binary operations, field access, function calls)
 - Statement execution (variable assignment, return, if statements, database queries)
@@ -14,7 +14,7 @@ This interpreter executes Glyph AST nodes directly without compilation to byteco
 
 ## Files
 
-- `ast.go` - AST type definitions for the Glyph language
+- `ast.go` - AST type definitions for the GlyphLang language
 - `environment.go` - Variable scope management
 - `evaluator.go` - Expression evaluation logic
 - `executor.go` - Statement execution logic
@@ -319,7 +319,7 @@ interpreter/
 ## Integration
 
 This interpreter is designed to work with:
-- **Parser** (pending): Converts Glyph source code to AST
+- **Parser** (pending): Converts GlyphLang source code to AST
 - **Runtime**: Provides HTTP server to route requests to interpreter
 - **Cache**: Stores compiled/parsed modules
 - **Database**: Executes database queries from routes

--- a/pkg/interpreter/evaluator.go
+++ b/pkg/interpreter/evaluator.go
@@ -622,7 +622,7 @@ func (i *Interpreter) evaluateFieldAccess(expr FieldAccessExpr, env *Environment
 	}
 
 	// Short-circuit on null before any reflection-based access to give a
-	// clean Glyph-level error instead of a Go panic or an opaque reflection error.
+	// clean GlyphLang-level error instead of a Go panic or an opaque reflection error.
 	if obj == nil {
 		return nil, fmt.Errorf("cannot access field %s on null", expr.Field)
 	}

--- a/pkg/interpreter/executor.go
+++ b/pkg/interpreter/executor.go
@@ -496,7 +496,7 @@ func (i *Interpreter) executeSwitch(stmt SwitchStatement, env *Environment) (int
 				return result, err
 			}
 
-			// In GLYPH, switch cases don't fall through by default
+			// In GlyphLang, switch cases don't fall through by default
 			return result, nil
 		}
 	}

--- a/pkg/interpreter/extra_coverage_test.go
+++ b/pkg/interpreter/extra_coverage_test.go
@@ -1153,7 +1153,7 @@ func TestFieldAccessOnArray(t *testing.T) {
 		Object: VariableExpr{Name: "arr"},
 		Field:  "length",
 	}, env)
-	// Arrays don't have field access in Glyph - this should fail or return nil
+	// Arrays don't have field access in GlyphLang - this should fail or return nil
 	// Just exercise the code path
 	_ = err
 }

--- a/pkg/interpreter/null_field_access_test.go
+++ b/pkg/interpreter/null_field_access_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 // TestNullFieldAccess_InRoute is a regression test for issue #236.
-// Accessing a field on a null value must produce a clean Glyph-level error
+// Accessing a field on a null value must produce a clean GlyphLang-level error
 // rather than a Go panic from reflect.Value.MethodByName.
 func TestNullFieldAccess_InRoute(t *testing.T) {
 	interp := NewInterpreter()

--- a/pkg/lsp/additional_test.go
+++ b/pkg/lsp/additional_test.go
@@ -1633,7 +1633,7 @@ func TestGetReferencesWithRoutes(t *testing.T) {
 func TestIsRenameableSymbolEdgeCases(t *testing.T) {
 	dm := NewDocumentManager()
 
-	// Use valid Glyph syntax that parses correctly
+	// Use valid GlyphLang syntax that parses correctly
 	source := `: User {
   name: str!
 }

--- a/pkg/lsp/features.go
+++ b/pkg/lsp/features.go
@@ -1740,7 +1740,7 @@ func generateSourceActions(doc *Document) []CodeAction {
 	var actions []CodeAction
 
 	// Add organize imports action (if applicable)
-	// For Glyph, this could organize type definitions
+	// For GlyphLang, this could organize type definitions
 	if doc.AST != nil {
 		hasTypes := false
 		hasRoutes := false

--- a/pkg/parser/errors.go
+++ b/pkg/parser/errors.go
@@ -190,15 +190,15 @@ func (l *Lexer) invalidCharacterError() error {
 	var hint string
 	switch {
 	case char >= 'A' && char <= 'Z':
-		hint = "Identifiers and keywords in GLYPH are case-sensitive"
+		hint = "Identifiers and keywords in GlyphLang are case-sensitive"
 	case char == ';':
-		hint = "GLYPH uses newlines for statement separation, not semicolons"
+		hint = "GlyphLang uses newlines for statement separation, not semicolons"
 	case char == '`':
 		hint = "Use double quotes (\") or single quotes (') for strings"
 	case char > 127:
-		hint = "GLYPH source code must use ASCII characters only"
+		hint = "GlyphLang source code must use ASCII characters only"
 	default:
-		hint = "This character is not valid in GLYPH syntax"
+		hint = "This character is not valid in GlyphLang syntax"
 	}
 
 	if hint != "" {

--- a/pkg/parser/lexer.go
+++ b/pkg/parser/lexer.go
@@ -8,7 +8,7 @@ import (
 	"unicode/utf8"
 )
 
-// Lexer tokenizes GLYPH source code
+// Lexer tokenizes GlyphLang source code
 type Lexer struct {
 	input             string
 	position          int

--- a/pkg/repl/commands.go
+++ b/pkg/repl/commands.go
@@ -49,7 +49,7 @@ func (r *REPL) executeCommand(line string) error {
 
 // cmdHelp displays help information.
 func (r *REPL) cmdHelp(args []string) error {
-	r.printf("Glyph REPL Commands:\n")
+	r.printf("GlyphLang REPL Commands:\n")
 	r.printf("====================\n\n")
 	r.printf("Commands:\n")
 	r.printf("  :help, :h              - Show this help message\n")

--- a/pkg/repl/repl.go
+++ b/pkg/repl/repl.go
@@ -490,7 +490,7 @@ func (r *REPL) GetInterpreter() *interpreter.Interpreter {
 	return r.interp
 }
 
-// LoadFile loads and executes a GlyphLang file.
+// LoadFile loads and executes a .glyph file.
 func (r *REPL) LoadFile(filepath string) error {
 	source, err := os.ReadFile(filepath)
 	if err != nil {

--- a/pkg/repl/repl.go
+++ b/pkg/repl/repl.go
@@ -1,4 +1,4 @@
-// Package repl provides an interactive Read-Eval-Print Loop for Glyph.
+// Package repl provides an interactive Read-Eval-Print Loop for GlyphLang.
 package repl
 
 import (
@@ -13,7 +13,7 @@ import (
 	"github.com/glyphlang/glyph/pkg/parser"
 )
 
-// REPL provides an interactive programming environment for Glyph.
+// REPL provides an interactive programming environment for GlyphLang.
 type REPL struct {
 	interp  *interpreter.Interpreter
 	env     *interpreter.Environment
@@ -406,7 +406,7 @@ func (r *REPL) isInputComplete(input string) bool {
 
 // printWelcome prints the welcome message.
 func (r *REPL) printWelcome() {
-	r.printf("Glyph REPL v%s\n", r.version)
+	r.printf("GlyphLang REPL v%s\n", r.version)
 	r.printf("Type :help for available commands, :quit to exit\n")
 	r.printf("=========================================\n\n")
 }
@@ -490,7 +490,7 @@ func (r *REPL) GetInterpreter() *interpreter.Interpreter {
 	return r.interp
 }
 
-// LoadFile loads and executes a Glyph file.
+// LoadFile loads and executes a GlyphLang file.
 func (r *REPL) LoadFile(filepath string) error {
 	source, err := os.ReadFile(filepath)
 	if err != nil {

--- a/pkg/repl/repl_test.go
+++ b/pkg/repl/repl_test.go
@@ -785,7 +785,7 @@ func TestLoadCommandWithExtension(t *testing.T) {
 	}
 }
 
-// TestLoadFileValidFile tests LoadFile with a valid Glyph file.
+// TestLoadFileValidFile tests LoadFile with a valid GlyphLang file.
 func TestLoadFileValidFile(t *testing.T) {
 	// Create a temporary .glyph file
 	tmpDir := t.TempDir()
@@ -828,7 +828,7 @@ func TestLoadFileNonexistent(t *testing.T) {
 	}
 }
 
-// TestLoadFileInvalidSyntax tests LoadFile with invalid Glyph syntax.
+// TestLoadFileInvalidSyntax tests LoadFile with invalid GlyphLang syntax.
 func TestLoadFileInvalidSyntax(t *testing.T) {
 	tmpDir := t.TempDir()
 	filePath := filepath.Join(tmpDir, "bad.glyph")
@@ -1033,7 +1033,7 @@ func TestHelpShortAlias(t *testing.T) {
 	r.Start()
 
 	result := output.String()
-	if !strings.Contains(result, "Glyph REPL Commands") {
+	if !strings.Contains(result, "GlyphLang REPL Commands") {
 		t.Errorf("Expected :h alias to show help, got %q", result)
 	}
 }
@@ -1380,7 +1380,7 @@ func TestExecuteCommandDirectly(t *testing.T) {
 		expected string
 		wantErr  bool
 	}{
-		{"help", ":help", "Glyph REPL Commands", false},
+		{"help", ":help", "GlyphLang REPL Commands", false},
 		{"types", ":types", "Type definitions", false},
 		{"functions no fns", ":functions", "No functions defined", false},
 		{"fns alias", ":fns", "No functions defined", false},

--- a/pkg/repl/repl_test.go
+++ b/pkg/repl/repl_test.go
@@ -785,7 +785,7 @@ func TestLoadCommandWithExtension(t *testing.T) {
 	}
 }
 
-// TestLoadFileValidFile tests LoadFile with a valid GlyphLang file.
+// TestLoadFileValidFile tests LoadFile with a valid .glyph file.
 func TestLoadFileValidFile(t *testing.T) {
 	// Create a temporary .glyph file
 	tmpDir := t.TempDir()

--- a/pkg/server/IMPLEMENTATION_REPORT.md
+++ b/pkg/server/IMPLEMENTATION_REPORT.md
@@ -278,7 +278,7 @@ The following could be added in future iterations:
 The server is ready to integrate with the GlyphLang compiler and interpreter:
 
 ```go
-// Parse GlyphLang file
+// Parse `.glyph` file
 ast := parser.Parse("main.glyph")
 
 // Extract routes from AST

--- a/pkg/server/IMPLEMENTATION_REPORT.md
+++ b/pkg/server/IMPLEMENTATION_REPORT.md
@@ -1,8 +1,8 @@
-# Glyph HTTP Server - Implementation Report
+# GlyphLang HTTP Server - Implementation Report
 
 ## Mission Status: COMPLETE
 
-I have successfully built a production-ready HTTP server for the Glyph language in Go.
+I have successfully built a production-ready HTTP server for the GlyphLang language in Go.
 
 ## Files Created
 
@@ -69,7 +69,7 @@ I have successfully built a production-ready HTTP server for the Glyph language 
 
 1. **main.go** (5,700 bytes)
    - Complete working demo server
-   - Implements all routes from Glyph examples
+   - Implements all routes from GlyphLang examples
    - Hello world endpoints
    - Full REST API for users
    - Nested resource support
@@ -100,7 +100,7 @@ I have successfully built a production-ready HTTP server for the Glyph language 
 - Configurable timeouts (read, write, idle)
 
 ### Route Management
-- Route registration from Glyph route definitions
+- Route registration from GlyphLang route definitions
 - Support for all HTTP methods: GET, POST, PUT, DELETE, PATCH
 - Path parameter extraction (`:id`, `:userId`, etc.)
 - Multiple path parameters in single route
@@ -273,12 +273,12 @@ The following could be added in future iterations:
 9. **Static Files**: Static file serving
 10. **Template Engine**: HTML template rendering
 
-## Integration with Glyph
+## Integration with GlyphLang
 
-The server is ready to integrate with the Glyph compiler and interpreter:
+The server is ready to integrate with the GlyphLang compiler and interpreter:
 
 ```go
-// Parse Glyph file
+// Parse GlyphLang file
 ast := parser.Parse("main.glyph")
 
 // Extract routes from AST
@@ -302,12 +302,12 @@ srv.Start(":8080")
 
 ## Conclusion
 
-The Glyph HTTP server implementation is complete, tested, and ready for production use. It provides a solid foundation for building backend APIs in Glyph with:
+The GlyphLang HTTP server implementation is complete, tested, and ready for production use. It provides a solid foundation for building backend APIs in GlyphLang with:
 
 - Clean, modular architecture
 - Comprehensive test coverage
 - Production-ready error handling
 - Excellent performance
-- Easy integration with Glyph compiler/interpreter
+- Easy integration with GlyphLang compiler/interpreter
 
 All deliverables have been completed successfully!

--- a/pkg/server/QUICKSTART.md
+++ b/pkg/server/QUICKSTART.md
@@ -1,6 +1,6 @@
-# Glyph HTTP Server - Quick Start Guide
+# GlyphLang HTTP Server - Quick Start Guide
 
-Get the Glyph HTTP server up and running in 5 minutes!
+Get the GlyphLang HTTP server up and running in 5 minutes!
 
 ## Prerequisites
 

--- a/pkg/server/README.md
+++ b/pkg/server/README.md
@@ -312,10 +312,10 @@ The mock will echo back request details (path, method, params, body) if no custo
 
 ## Integration with GlyphLang
 
-When integrated with the GlyphLang compiler and interpreter, routes will be registered from parsed GlyphLang source files:
+When integrated with the GlyphLang compiler and interpreter, routes will be registered from parsed `.glyph` source files:
 
 ```go
-// Parse GlyphLang file
+// Parse `.glyph` file
 routes := parser.Parse("main.glyph")
 
 // Register with server

--- a/pkg/server/README.md
+++ b/pkg/server/README.md
@@ -1,6 +1,6 @@
-# Glyph HTTP Server
+# GlyphLang HTTP Server
 
-A production-ready HTTP server implementation for the Glyph language that handles route registration, request/response processing, and middleware execution.
+A production-ready HTTP server implementation for the GlyphLang language that handles route registration, request/response processing, and middleware execution.
 
 ## Features
 
@@ -18,11 +18,11 @@ A production-ready HTTP server implementation for the Glyph language that handle
 The server is composed of several components:
 
 ### Core Types (`types.go`)
-- `Route`: Represents an Glyph route definition
+- `Route`: Represents an GlyphLang route definition
 - `Context`: Request context with parsed parameters
 - `RouteHandler`: Function signature for route handlers
 - `Middleware`: Function signature for middleware
-- `Interpreter`: Interface for executing Glyph route logic
+- `Interpreter`: Interface for executing GlyphLang route logic
 
 ### Router (`router.go`)
 - Route registration and storage
@@ -310,12 +310,12 @@ srv := server.NewServer(server.WithInterpreter(interpreter))
 
 The mock will echo back request details (path, method, params, body) if no custom response is set.
 
-## Integration with Glyph
+## Integration with GlyphLang
 
-When integrated with the Glyph compiler and interpreter, routes will be registered from parsed Glyph source files:
+When integrated with the GlyphLang compiler and interpreter, routes will be registered from parsed GlyphLang source files:
 
 ```go
-// Parse Glyph file
+// Parse GlyphLang file
 routes := parser.Parse("main.glyph")
 
 // Register with server
@@ -325,7 +325,7 @@ srv.RegisterRoutes(routes)
 srv.Start(":8080")
 ```
 
-The interpreter will execute the Glyph route logic when requests are received.
+The interpreter will execute the GlyphLang route logic when requests are received.
 
 ## Performance
 

--- a/pkg/server/pathparams.go
+++ b/pkg/server/pathparams.go
@@ -63,7 +63,7 @@ func ExtractPathParamValues(pattern, actualPath string) map[string]string {
 	return params
 }
 
-// ConvertPatternToMuxFormat converts Glyph's :param syntax to Go's {param} syntax
+// ConvertPatternToMuxFormat converts GlyphLang's :param syntax to Go's {param} syntax
 // for http.ServeMux pattern matching.
 // e.g., "/chat/:room" becomes "/chat/{room}"
 func ConvertPatternToMuxFormat(pattern string) string {

--- a/pkg/server/types.go
+++ b/pkg/server/types.go
@@ -13,7 +13,7 @@ const (
 	PATCH  HTTPMethod = "PATCH"
 )
 
-// Route represents a parsed GLYPH route definition
+// Route represents a parsed GlyphLang route definition
 type Route struct {
 	Method      HTTPMethod
 	Path        string
@@ -37,7 +37,7 @@ type Context struct {
 // Middleware is a function that wraps a handler
 type Middleware func(next RouteHandler) RouteHandler
 
-// Interpreter interface for executing GLYPH route logic
+// Interpreter interface for executing GlyphLang route logic
 // This will be properly implemented later - for now we mock it
 type Interpreter interface {
 	Execute(route *Route, ctx *Context) (interface{}, error)

--- a/pkg/validate/validate.go
+++ b/pkg/validate/validate.go
@@ -1,4 +1,4 @@
-// Package validate provides AI-friendly validation for Glyph source files.
+// Package validate provides AI-friendly validation for GlyphLang source files.
 // It returns structured errors that AI agents can easily parse and act upon.
 package validate
 
@@ -13,7 +13,7 @@ import (
 	"github.com/glyphlang/glyph/pkg/parser"
 )
 
-// ValidationResult contains the results of validating a Glyph file
+// ValidationResult contains the results of validating a GlyphLang file
 type ValidationResult struct {
 	Valid    bool               `json:"valid"`
 	FilePath string             `json:"file_path"`
@@ -63,7 +63,7 @@ const (
 	ErrTypeInvalidType  = "invalid_type"
 )
 
-// Validator validates Glyph source code
+// Validator validates GlyphLang source code
 type Validator struct {
 	source   string
 	filePath string
@@ -543,7 +543,7 @@ func (v *Validator) suggestParseFix(errStr string) string {
 		return "complete the statement or block"
 	}
 
-	return "review Glyph syntax documentation"
+	return "review GlyphLang syntax documentation"
 }
 
 // ToJSON serializes the result to JSON

--- a/pkg/validate/validate.go
+++ b/pkg/validate/validate.go
@@ -1,4 +1,4 @@
-// Package validate provides AI-friendly validation for GlyphLang source files.
+// Package validate provides AI-friendly validation for .glyph source files.
 // It returns structured errors that AI agents can easily parse and act upon.
 package validate
 
@@ -13,7 +13,7 @@ import (
 	"github.com/glyphlang/glyph/pkg/parser"
 )
 
-// ValidationResult contains the results of validating a GlyphLang file
+// ValidationResult contains the results of validating a .glyph file
 type ValidationResult struct {
 	Valid    bool               `json:"valid"`
 	FilePath string             `json:"file_path"`

--- a/pkg/validation/README.md
+++ b/pkg/validation/README.md
@@ -1,6 +1,6 @@
-# Glyph Validation Package
+# GlyphLang Validation Package
 
-The validation package provides comprehensive validation rule enforcement for the Glyph language. It includes built-in validators for common validation scenarios and a flexible framework for custom validation logic.
+The validation package provides comprehensive validation rule enforcement for the GlyphLang language. It includes built-in validators for common validation scenarios and a flexible framework for custom validation logic.
 
 ## Features
 
@@ -15,7 +15,7 @@ The validation package provides comprehensive validation rule enforcement for th
 
 ## Installation
 
-The validation package is part of the Glyph project and can be imported as:
+The validation package is part of the GlyphLang project and can be imported as:
 
 ```go
 import "github.com/glyphlang/glyph/pkg/validation"
@@ -509,4 +509,4 @@ Test coverage includes:
 
 ## License
 
-Part of the Glyph language project.
+Part of the GlyphLang language project.

--- a/pkg/websocket/README.md
+++ b/pkg/websocket/README.md
@@ -1,6 +1,6 @@
-# WebSocket Support for Glyph
+# WebSocket Support for GlyphLang
 
-Production-ready WebSocket implementation for real-time bidirectional communication in Glyph.
+Production-ready WebSocket implementation for real-time bidirectional communication in GlyphLang.
 
 ## Features
 
@@ -10,7 +10,7 @@ Production-ready WebSocket implementation for real-time bidirectional communicat
 - **Broadcast Operations**: Send to all connections, specific rooms, or individual clients
 - **Ping/Pong Keep-Alive**: Automatic connection health monitoring
 - **Event Handlers**: Custom event handling for connect, disconnect, and messages
-- **Integration Ready**: Seamlessly integrates with Glyph HTTP server
+- **Integration Ready**: Seamlessly integrates with GlyphLang HTTP server
 
 ## Architecture
 
@@ -59,7 +59,7 @@ func main() {
 }
 ```
 
-### Glyph Language Syntax
+### GlyphLang Syntax
 
 ```glyph
 // WebSocket route
@@ -132,7 +132,7 @@ See `examples/websocket-chat/` for a complete chat application with:
 - Multiple chat rooms
 - User presence
 - HTML/JavaScript client
-- Glyph backend
+- GlyphLang backend
 
 ## Production Considerations
 
@@ -188,9 +188,9 @@ See `examples/websocket-chat/` for a complete chat application with:
 - `Size()`: Get room size
 - `SetMetadata(key, value)`: Set room metadata
 
-## Integration with Glyph Server
+## Integration with GlyphLang Server
 
-The WebSocket server integrates seamlessly with the Glyph HTTP server:
+The WebSocket server integrates seamlessly with the GlyphLang HTTP server:
 
 ```go
 server := server.NewServer()
@@ -202,4 +202,4 @@ server.RegisterWebSocketRoute("/chat", wsServer.HandleWebSocket)
 
 ## License
 
-Part of the Glyph project.
+Part of the GlyphLang project.

--- a/scripts/init-db.sql
+++ b/scripts/init-db.sql
@@ -1,4 +1,4 @@
--- Glyph Database Initialization Script
+-- GlyphLang Database Initialization Script
 
 -- Create extensions
 CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
@@ -7,7 +7,7 @@ CREATE EXTENSION IF NOT EXISTS "pg_trgm";
 -- Create schemas
 CREATE SCHEMA IF NOT EXISTS glyph;
 
--- Example tables for Glyph applications
+-- Example tables for GlyphLang applications
 
 -- Users table
 CREATE TABLE IF NOT EXISTS glyph.users (

--- a/test_cli.sh
+++ b/test_cli.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
-# Glyph CLI Integration Test Script
+# GlyphLang CLI Integration Test Script
 # This script tests the CLI commands with the example files
 
 set -e
 
-echo "=== Glyph CLI Integration Tests ==="
+echo "=== GlyphLang CLI Integration Tests ==="
 echo ""
 
 # Colors for output
@@ -15,7 +15,7 @@ YELLOW='\033[1;33m'
 NC='\033[0m' # No Color
 
 # Build the CLI
-echo "Building Glyph CLI..."
+echo "Building GlyphLang CLI..."
 go build -o build/glyph ./cmd/glyph
 if [ $? -ne 0 ]; then
     echo -e "${RED}[FAIL]${NC} Build failed"

--- a/tests/QUICK_START.md
+++ b/tests/QUICK_START.md
@@ -1,6 +1,6 @@
-# Glyph Tests - Quick Start Guide
+# GlyphLang Tests - Quick Start Guide
 
-Get up and running with Glyph tests in 5 minutes.
+Get up and running with GlyphLang tests in 5 minutes.
 
 ## Prerequisites
 
@@ -370,7 +370,7 @@ go test ./tests/... -v -timeout 30m
 
 ## Success!
 
-You're ready to start testing Glyph! As components are implemented, enable tests and watch the project come to life.
+You're ready to start testing GlyphLang! As components are implemented, enable tests and watch the project come to life.
 
 ```bash
 # Watch progress with:

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,6 +1,6 @@
-# Glyph Test Suite
+# GlyphLang Test Suite
 
-Comprehensive test infrastructure for the Glyph project.
+Comprehensive test infrastructure for the GlyphLang project.
 
 ## Test Structure
 
@@ -11,7 +11,7 @@ tests/
 ├── e2e_test.go                 # End-to-end integration tests
 ├── integration_test.go         # Component integration tests
 ├── benchmark_test.go           # Performance benchmarks
-└── fixtures/                   # Test Glyph programs
+└── fixtures/                   # Test GlyphLang programs
     ├── simple_route.glyph
     ├── path_param.glyph
     ├── json_response.glyph
@@ -94,7 +94,7 @@ Tests complete workflows from source code to execution:
 
 Tests individual components and their integration:
 
-- **TestParserIntegration**: Tests parser with various Glyph syntax
+- **TestParserIntegration**: Tests parser with various GlyphLang syntax
 - **TestLexerIntegration**: Tests lexer token generation
 - **TestTypeCheckerIntegration**: Tests type checking and validation
 - **TestInterpreterIntegration**: Tests AST interpretation (skipped)
@@ -129,7 +129,7 @@ Measures performance of various operations:
 
 ## Test Fixtures
 
-Test fixtures are small Glyph programs in `fixtures/` directory:
+Test fixtures are small GlyphLang programs in `fixtures/` directory:
 
 1. **simple_route.glyph**: Basic route returning JSON
 2. **path_param.glyph**: Route with path parameter (`:name`)
@@ -379,7 +379,7 @@ Planned test areas:
 - [Go Testing Package](https://pkg.go.dev/testing)
 - [Go Benchmarking](https://dave.cheney.net/2013/06/30/how-to-write-benchmarks-in-go)
 - [Table-Driven Tests](https://dave.cheney.net/2019/05/07/prefer-table-driven-tests)
-- [Glyph Project Context](../CONTEXT.md)
+- [GlyphLang Project Context](../CONTEXT.md)
 
 ---
 

--- a/tests/TEST_ARCHITECTURE.md
+++ b/tests/TEST_ARCHITECTURE.md
@@ -1,12 +1,12 @@
-# Glyph Test Architecture
+# GlyphLang Test Architecture
 
-Visual representation of the test infrastructure and how it validates the Glyph system.
+Visual representation of the test infrastructure and how it validates the GlyphLang system.
 
 ## Test Organization
 
 ```
 ┌─────────────────────────────────────────────────────────────────┐
-│                    Glyph Test Infrastructure                     │
+│                    GlyphLang Test Infrastructure                     │
 ├─────────────────────────────────────────────────────────────────┤
 │                                                                 │
 │  ┌───────────────────────────────────────────────────────────┐ │
@@ -93,7 +93,7 @@ Visual representation of the test infrastructure and how it validates the Glyph 
 │  │  json_response.glyph     │  post_route.glyph                 │ │
 │  │  invalid_syntax.glyph    │  error_handling.glyph             │ │
 │  │                                                           │ │
-│  │  Fixtures: 8 realistic Glyph programs for testing         │ │
+│  │  Fixtures: 8 realistic GlyphLang programs for testing         │ │
 │  └───────────────────────────────────────────────────────────┘ │
 │                                                                 │
 └─────────────────────────────────────────────────────────────────┘
@@ -106,7 +106,7 @@ Visual representation of the test infrastructure and how it validates the Glyph 
 │                     Test Execution Flow                         │
 └─────────────────────────────────────────────────────────────────┘
 
-Developer writes Glyph code
+Developer writes GlyphLang code
          │
          ├─────────────────────────────────┐
          │                                 │
@@ -337,7 +337,7 @@ fixtures/simple_route.glyph
     │ compiler.Compile()
     ↓
 ┌────────────────────────┐
-│ Bytecode: Glyph\x01...  │
+│ Bytecode: GlyphLang\x01...  │
 └────────────────────────┘
     │
     │ vm.Execute()

--- a/tests/examples_e2e_test.go
+++ b/tests/examples_e2e_test.go
@@ -198,7 +198,7 @@ func TestExampleProgramModuleStructure(t *testing.T) {
 func TestInterpreterRouteExecution(t *testing.T) {
 	t.Run("simple route returns response", func(t *testing.T) {
 		source := `@ GET /test {
-  > {status: "ok", message: "Hello from Glyph"}
+  > {status: "ok", message: "Hello from GlyphLang"}
 }`
 		module, err := parseSource(source)
 		if err != nil {
@@ -408,7 +408,7 @@ func TestFullPipelineHTTPServer(t *testing.T) {
 		mockInterp := &MockConcurrentInterpreter{
 			response: map[string]interface{}{
 				"status":  "ok",
-				"message": "Hello from Glyph E2E test",
+				"message": "Hello from GlyphLang E2E test",
 			},
 		}
 

--- a/tests/helpers.go
+++ b/tests/helpers.go
@@ -13,7 +13,7 @@ import (
 	"time"
 )
 
-// TestHelper provides utilities for GLYPH tests
+// TestHelper provides utilities for GlyphLang tests
 type TestHelper struct {
 	t *testing.T
 }
@@ -205,7 +205,7 @@ func (m *CompilerMock) CompileFile(filename string) ([]byte, error) {
 	return nil, fmt.Errorf("not implemented")
 }
 
-// ParseResult represents parsed GLYPH code for testing
+// ParseResult represents parsed GlyphLang code for testing
 type ParseResult struct {
 	Success bool
 	AST     interface{}

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/glyphlang/glyph/pkg/vm"
 )
 
-// TestParserIntegration tests the parser with real GLYPH programs
+// TestParserIntegration tests the parser with real GlyphLang programs
 func TestParserIntegration(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/tests/intent-hypothesis/METHODOLOGY.md
+++ b/tests/intent-hypothesis/METHODOLOGY.md
@@ -2,7 +2,7 @@
 
 ## Hypothesis
 
-Glyph notation (`.glyph`) produces more correct, complete, and structurally precise AI-generated code than equivalent natural language descriptions (`.txt`) when used as input prompts for large language models.
+GlyphLang notation (`.glyph`) produces more correct, complete, and structurally precise AI-generated code than equivalent natural language descriptions (`.txt`) when used as input prompts for large language models.
 
 ## Experimental Design
 
@@ -24,7 +24,7 @@ Glyph notation (`.glyph`) produces more correct, complete, and structurally prec
 ### Generation Protocol
 
 For each scenario, the LLM receives:
-1. **Glyph condition**: The `.glyph` file + a standard prompt: *"Generate a complete Python/FastAPI implementation from this Glyph specification."*
+1. **GlyphLang condition**: The `.glyph` file + a standard prompt: *"Generate a complete Python/FastAPI implementation from this GlyphLang specification."*
 2. **Text condition**: The `.txt` file + a standard prompt: *"Generate a complete Python/FastAPI implementation from this description."*
 
 Each generation is performed in an isolated context (separate sub-agent) to prevent cross-contamination.

--- a/tests/intent-hypothesis/RESULTS.md
+++ b/tests/intent-hypothesis/RESULTS.md
@@ -2,7 +2,7 @@
 
 ## Hypothesis
 
-> Glyph notation (`.glyph`) produces more correct, complete, and structurally precise AI-generated code than equivalent natural language descriptions (`.txt`) when used as input prompts for large language models.
+> GlyphLang notation (`.glyph`) produces more correct, complete, and structurally precise AI-generated code than equivalent natural language descriptions (`.txt`) when used as input prompts for large language models.
 
 ## Generation Details
 
@@ -10,7 +10,7 @@
 - **Target language**: Python / FastAPI
 - **Generation protocol**: Each implementation generated in an isolated sub-agent context
 - **Total implementations**: 15 (5 glyph-sourced + 5 text-sourced + 5 openapi-sourced)
-- **Conditions**: Three-way comparison — Glyph (.glyph), natural language (.txt), OpenAPI 3.1.0 (.yaml)
+- **Conditions**: Three-way comparison — GlyphLang (.glyph), natural language (.txt), OpenAPI 3.1.0 (.yaml)
 
 ---
 
@@ -58,7 +58,7 @@ openapi/05-auth-service.py     PASS
 | text/05-auth-service.py | fastapi, jose, passlib, pydantic | 8 | 24 | 6 (get:2, post:4) |
 | openapi/05-auth-service.py | fastapi, pydantic, uvicorn | 8 | 18 | 6 (get:2, post:4) |
 
-**Observation**: Route decorator counts are identical across all three conditions in every scenario — all notations produce the same endpoint structure. The differences are in classes and functions: glyph-generated code averages 7.8 classes vs text's 5.4 vs openapi's 4.4. Glyph produces the most structured abstractions (collection classes, worker classes, bus classes). OpenAPI produces the fewest classes but includes uvicorn as an extra dependency. Notably, OpenAPI-generated code never imports external JWT or crypto libraries — it either implements JWT manually or uses stub auth.
+**Observation**: Route decorator counts are identical across all three conditions in every scenario — all notations produce the same endpoint structure. The differences are in classes and functions: glyph-generated code averages 7.8 classes vs text's 5.4 vs openapi's 4.4. GlyphLang produces the most structured abstractions (collection classes, worker classes, bus classes). OpenAPI produces the fewest classes but includes uvicorn as an extra dependency. Notably, OpenAPI-generated code never imports external JWT or crypto libraries — it either implements JWT manually or uses stub auth.
 
 ### Output File Sizes
 
@@ -174,7 +174,7 @@ Each implementation was scored against its own specification using 15 binary che
 | Completeness | **8** — Missing Database DI pattern. All endpoints and models present. |
 | Structural Precision | **7** — No Depends() DI pattern at all. No Database abstraction. |
 
-**Scenario 01 Summary**: Glyph 29/30, Text 27/30, OpenAPI 25/30. Glyph's minor deduction is error response shape (`detail` vs `error`); text's is the wrong DELETE response body. OpenAPI has the best correctness (exact response shapes from schema) but lacks DI patterns entirely.
+**Scenario 01 Summary**: GlyphLang 29/30, Text 27/30, OpenAPI 25/30. GlyphLang's minor deduction is error response shape (`detail` vs `error`); text's is the wrong DELETE response body. OpenAPI has the best correctness (exact response shapes from schema) but lacks DI patterns entirely.
 
 ---
 
@@ -258,7 +258,7 @@ Each implementation was scored against its own specification using 15 binary che
 | Completeness | **8** — Missing Database DI pattern. All endpoints, models, auth, rate limiting present. |
 | Structural Precision | **8** — Missing Depends() for DB. Good use of Security/APIKeyHeader for auth. |
 
-**Scenario 02 Summary**: Glyph 30/30, Text 21/30, OpenAPI 26/30. Glyph's `+ ratelimit(1000/min)` and `+ auth(apikey)` middleware symbols mapped directly to separate Depends() dependencies. `% db: Database` produced injected collection classes. OpenAPI's security scheme and x-ratelimit produced correct auth and rate limiting but no DI. Text's prose produced the weakest implementation — wrong field names (`payment_id` vs `id`) and no DI.
+**Scenario 02 Summary**: GlyphLang 30/30, Text 21/30, OpenAPI 26/30. GlyphLang's `+ ratelimit(1000/min)` and `+ auth(apikey)` middleware symbols mapped directly to separate Depends() dependencies. `% db: Database` produced injected collection classes. OpenAPI's security scheme and x-ratelimit produced correct auth and rate limiting but no DI. Text's prose produced the weakest implementation — wrong field names (`payment_id` vs `id`) and no DI.
 
 ---
 
@@ -342,7 +342,7 @@ Each implementation was scored against its own specification using 15 binary che
 | Completeness | **6** — Missing real JWT auth and Database DI |
 | Structural Precision | **6** — No DI for DB, missing type annotations, stub auth |
 
-**Scenario 03 Summary**: Glyph 30/30, Text 30/30, OpenAPI 20/30. Both glyph and text produce excellent chat server implementations. OpenAPI's biggest weakness here: `bearerAuth` security scheme declares JWT but the generated code only checks for token presence, never decodes it. x-websocket extension was handled well.
+**Scenario 03 Summary**: GlyphLang 30/30, Text 30/30, OpenAPI 20/30. Both glyph and text produce excellent chat server implementations. OpenAPI's biggest weakness here: `bearerAuth` security scheme declares JWT but the generated code only checks for token presence, never decodes it. x-websocket extension was handled well.
 
 ---
 
@@ -426,7 +426,7 @@ Each implementation was scored against its own specification using 15 binary che
 | Completeness | **6** — Stub JWT auth, no Database DI. Background tasks present but no DB layer. |
 | Structural Precision | **8** — Missing DB Depends(), but workers and cron are async. |
 
-**Scenario 04 Summary**: Glyph 30/30, Text 24/30, OpenAPI 24/30. Text and OpenAPI tie but fail differently. Text has correct response shapes but wrong field names (`recipient` vs `to`, `notification` vs `queued`) and sync workers. OpenAPI has correct field names and async workers but no DI and stub auth. Glyph's `&`, `*`, `~` symbols produce the only complete implementation with full infrastructure classes.
+**Scenario 04 Summary**: GlyphLang 30/30, Text 24/30, OpenAPI 24/30. Text and OpenAPI tie but fail differently. Text has correct response shapes but wrong field names (`recipient` vs `to`, `notification` vs `queued`) and sync workers. OpenAPI has correct field names and async workers but no DI and stub auth. GlyphLang's `&`, `*`, `~` symbols produce the only complete implementation with full infrastructure classes.
 
 ---
 
@@ -510,7 +510,7 @@ Each implementation was scored against its own specification using 15 binary che
 | Completeness | **9** — All endpoints, models, middleware, cron present. Error model and custom handler are good additions. |
 | Structural Precision | **7** — No DB Depends(), missing return type annotations, manual JWT implementation. |
 
-**Scenario 05 Summary**: Glyph 28/30, Text 25/30, OpenAPI 25/30. Glyph leads with best structural precision. Text has type mismatches (str vs int for timestamps). OpenAPI has the most thorough correctness (extra refresh validation, Error schema handler) but lacks DI and return type annotations.
+**Scenario 05 Summary**: GlyphLang 28/30, Text 25/30, OpenAPI 25/30. GlyphLang leads with best structural precision. Text has type mismatches (str vs int for timestamps). OpenAPI has the most thorough correctness (extra refresh validation, Error schema handler) but lacks DI and return type annotations.
 
 ---
 
@@ -518,7 +518,7 @@ Each implementation was scored against its own specification using 15 binary che
 
 ### Score Comparison Table
 
-| Scenario | Complexity | Glyph C | Text C | OA C | Glyph Cm | Text Cm | OA Cm | Glyph SP | Text SP | OA SP | Glyph | Text | OpenAPI |
+| Scenario | Complexity | GlyphLang C | Text C | OA C | GlyphLang Cm | Text Cm | OA Cm | GlyphLang SP | Text SP | OA SP | GlyphLang | Text | OpenAPI |
 |----------|-----------|---------|--------|------|----------|---------|-------|----------|---------|-------|-------|------|---------|
 | 01 CRUD API | Low | 9 | 7 | 10 | 10 | 10 | 8 | 10 | 10 | 7 | **29** | 27 | 25 |
 | 02 Webhook | Medium | 10 | 7 | 10 | 10 | 7 | 8 | 10 | 7 | 8 | **30** | 21 | 26 |
@@ -530,7 +530,7 @@ Each implementation was scored against its own specification using 15 binary che
 
 ### Per-Metric Averages
 
-| Metric | Glyph | Text | OpenAPI | Glyph vs Text | Glyph vs OA |
+| Metric | GlyphLang | Text | OpenAPI | GlyphLang vs Text | GlyphLang vs OA |
 |--------|-------|------|---------|---------------|-------------|
 | Correctness | 9.6 | 7.4 | 9.4 | +2.2 | +0.2 |
 | Completeness | 9.8 | 9.2 | 7.4 | +0.6 | **+2.4** |
@@ -541,11 +541,11 @@ Each implementation was scored against its own specification using 15 binary che
 
 | Condition | Items Passed | Total Items | Pass Rate |
 |-----------|-------------|-------------|-----------|
-| Glyph | 75 | 75 | **100%** |
+| GlyphLang | 75 | 75 | **100%** |
 | Text | 67 | 75 | **89.3%** |
 | OpenAPI | 62 | 75 | **82.7%** |
 
-**Glyph**: 75/75 — zero failures.
+**GlyphLang**: 75/75 — zero failures.
 
 **Text** (8 failures): C1 on 01 (wrong DELETE shape), C4 on 02 (wrong field name `payment_id`), Cm5 on 02 (global stores), S2 on 02 (inline rate limit), C1 on 04 (reduced response shape), C4 on 04 (wrong field names `recipient`/`notification`), S5 on 04 (sync workers), C3 on 05 (str vs int timestamps).
 
@@ -553,7 +553,7 @@ Each implementation was scored against its own specification using 15 binary che
 
 ### Token Efficiency
 
-| Scenario | Glyph In | Text In | OA In | Glyph Score | Text Score | OA Score | Glyph QPW | Text QPW | OA QPW |
+| Scenario | GlyphLang In | Text In | OA In | GlyphLang Score | Text Score | OA Score | GlyphLang QPW | Text QPW | OA QPW |
 |----------|----------|---------|-------|-------------|------------|----------|-----------|----------|--------|
 | 01 CRUD | 176 | 138 | 207 | 9.67 | 9.00 | 8.33 | 5.49 | 6.52 | 4.02 |
 | 02 Webhook | 130 | 151 | 145 | 10.00 | 7.00 | 8.67 | 7.69 | 4.64 | 5.98 |
@@ -564,7 +564,7 @@ Each implementation was scored against its own specification using 15 binary che
 
 *QPW = Quality-Per-Word = Average(Correctness, Completeness, Structural Precision) / Input Words × 100*
 
-**Glyph leads on token efficiency** (5.23 QPW) — it uses more input words than text (236 vs 187) but produces proportionally more quality. OpenAPI is the least token-efficient (3.94 QPW) — its verbose YAML schema notation (avg 227 words) does not produce correspondingly high quality, especially in completeness and structural precision.
+**GlyphLang leads on token efficiency** (5.23 QPW) — it uses more input words than text (236 vs 187) but produces proportionally more quality. OpenAPI is the least token-efficient (3.94 QPW) — its verbose YAML schema notation (avg 227 words) does not produce correspondingly high quality, especially in completeness and structural precision.
 
 ---
 
@@ -572,24 +572,24 @@ Each implementation was scored against its own specification using 15 binary che
 
 *Note: The three-way comparison uses fresh evaluation scores from three independent agents scoring all 15 implementations simultaneously. Scores may differ slightly from the original two-way evaluation above due to inter-evaluator variance — this is expected and documented as a limitation.*
 
-### Finding 1: Glyph Outperforms Both Alternatives
+### Finding 1: GlyphLang Outperforms Both Alternatives
 
-Glyph scored 9.80/10 vs text 8.47/10 (+1.33) and OpenAPI 8.00/10 (+1.80). Glyph won or tied in all 5 scenarios. The advantage over text is driven by correctness (+2.2) and structural precision (+1.2). The advantage over OpenAPI is driven by completeness (+2.4) and structural precision (+2.8).
+GlyphLang scored 9.80/10 vs text 8.47/10 (+1.33) and OpenAPI 8.00/10 (+1.80). GlyphLang won or tied in all 5 scenarios. The advantage over text is driven by correctness (+2.2) and structural precision (+1.2). The advantage over OpenAPI is driven by completeness (+2.4) and structural precision (+2.8).
 
 ### Finding 2: Each Format Has a Distinct Strength Profile
 
-| Strength | Glyph | Text | OpenAPI |
+| Strength | GlyphLang | Text | OpenAPI |
 |----------|-------|------|---------|
 | Best metric | Structural Precision (10.0) | Completeness (9.2) | Correctness (9.4) |
 | Worst metric | Correctness (9.6) | Correctness (7.4) | Structural Precision (7.2) |
 
-- **Glyph** excels at producing idiomatic framework patterns — `Depends()` DI, typed collections, class abstractions. 100% checklist pass rate.
+- **GlyphLang** excels at producing idiomatic framework patterns — `Depends()` DI, typed collections, class abstractions. 100% checklist pass rate.
 - **OpenAPI** excels at response shape correctness — explicit schemas translate to precise API contracts and custom Error handlers. But it fails to convey DI patterns or authentication implementation.
 - **Text** falls between — it captures behavioral intent but introduces field-name drift and structural imprecision.
 
-### Finding 3: Structural Precision Is Glyph's Strongest Advantage
+### Finding 3: Structural Precision Is GlyphLang's Strongest Advantage
 
-Glyph's symbolic notation directly maps to FastAPI patterns:
+GlyphLang's symbolic notation directly maps to FastAPI patterns:
 - `+ auth(jwt)` → `Depends(auth)` middleware
 - `+ ratelimit(N/min)` → `Depends(check_rate_limit)` dependency
 - `% db: Database` → `Depends(get_db)` injection with typed collection classes
@@ -614,9 +614,9 @@ Text's biggest weakness is field-name drift — natural language doesn't pin exa
 - Scenario 04: Returns `recipient` instead of `to`, `notification` instead of `queued`
 - Scenario 05: Uses `str` for timestamps instead of `int`
 
-### Finding 6: Glyph's Advantage Is Concentrated in Middleware-Heavy Scenarios
+### Finding 6: GlyphLang's Advantage Is Concentrated in Middleware-Heavy Scenarios
 
-| Scenario | Glyph | Text | OpenAPI | Glyph Lead vs Text | Glyph Lead vs OA |
+| Scenario | GlyphLang | Text | OpenAPI | GlyphLang Lead vs Text | GlyphLang Lead vs OA |
 |----------|-------|------|---------|---------------------|-------------------|
 | 01 CRUD | 29 | 27 | 25 | +2 | +4 |
 | 02 Webhook | 30 | 21 | 26 | **+9** | +4 |
@@ -631,10 +631,10 @@ Each format captures a different layer of intent:
 | Layer | Best Format | What It Captures |
 |-------|-------------|------------------|
 | HTTP interface | OpenAPI | Paths, methods, schemas, status codes, security declarations |
-| Architecture | Glyph | DI patterns, middleware composition, background infrastructure |
+| Architecture | GlyphLang | DI patterns, middleware composition, background infrastructure |
 | Behavior | Text | Business rules, edge cases, security considerations, protocol semantics |
 
-A hybrid approach — OpenAPI for the API surface, Glyph for the structural scaffold, text annotations for behavioral nuance — could outperform any single format.
+A hybrid approach — OpenAPI for the API surface, GlyphLang for the structural scaffold, text annotations for behavioral nuance — could outperform any single format.
 
 ---
 
@@ -669,16 +669,16 @@ The rubric scores (0-10) supplement the checklists with qualitative judgment, bu
 
 ## Conclusion
 
-**The hypothesis is confirmed across a three-way comparison.** Glyph notation produces code that is more structurally precise (+2.8 vs OpenAPI, +1.2 vs text), more complete (+2.4 vs OpenAPI, +0.6 vs text), and more correct (+0.2 vs OpenAPI, +2.2 vs text) than both alternatives. Glyph achieved a 100% checklist pass rate (75/75) vs text's 89.3% (67/75) and OpenAPI's 82.7% (62/75).
+**The hypothesis is confirmed across a three-way comparison.** GlyphLang notation produces code that is more structurally precise (+2.8 vs OpenAPI, +1.2 vs text), more complete (+2.4 vs OpenAPI, +0.6 vs text), and more correct (+0.2 vs OpenAPI, +2.2 vs text) than both alternatives. GlyphLang achieved a 100% checklist pass rate (75/75) vs text's 89.3% (67/75) and OpenAPI's 82.7% (62/75).
 
 **The three formats occupy distinct niches:**
-- **Glyph** (9.80/10): Best overall — its symbols map directly to framework idioms, producing idiomatic DI, middleware, and infrastructure patterns.
+- **GlyphLang** (9.80/10): Best overall — its symbols map directly to framework idioms, producing idiomatic DI, middleware, and infrastructure patterns.
 - **Text** (8.47/10): Best for behavioral nuance — security patterns, protocol semantics, edge cases. Weakest on exact field names and response shapes.
 - **OpenAPI** (8.00/10): Best for API contracts — explicit schemas produce correct response shapes. Weakest on implementation details (DI, auth verification, return annotations).
 
-**Key insight**: Glyph's value is in making structural intent unambiguous. `+ ratelimit(1000/min)` maps to a `Depends()` dependency. `bearerAuth` in OpenAPI just declares JWT is used. "Rate limited to 1000 requests per minute" gets implemented as an inline function call. The three formats encode intent at different abstraction levels.
+**Key insight**: GlyphLang's value is in making structural intent unambiguous. `+ ratelimit(1000/min)` maps to a `Depends()` dependency. `bearerAuth` in OpenAPI just declares JWT is used. "Rate limited to 1000 requests per minute" gets implemented as an inline function call. The three formats encode intent at different abstraction levels.
 
-**Recommendation**: Glyph notation is most valuable as a structural scaffold for middleware, data models, and service architecture. A hybrid approach — OpenAPI for HTTP contracts, Glyph for architectural patterns, text for behavioral specs — would leverage each format's strength.
+**Recommendation**: GlyphLang notation is most valuable as a structural scaffold for middleware, data models, and service architecture. A hybrid approach — OpenAPI for HTTP contracts, GlyphLang for architectural patterns, text for behavioral specs — would leverage each format's strength.
 
 ---
 

--- a/tests/static_route_test.go
+++ b/tests/static_route_test.go
@@ -16,9 +16,9 @@ import (
 
 func TestStaticRouteParseThenServe(t *testing.T) {
 	// Create a temp directory with a test file. Use forward slashes in the
-	// path so it can be embedded in a Glyph string literal: on Windows
+	// path so it can be embedded in a GlyphLang string literal: on Windows
 	// t.TempDir() returns a backslash path, and backslashes are escape
-	// sequences in Glyph strings. Windows accepts forward slashes for file I/O.
+	// sequences in GlyphLang strings. Windows accepts forward slashes for file I/O.
 	tmpDir := filepath.ToSlash(t.TempDir())
 	testContent := []byte("hello from static file")
 	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "test.txt"), testContent, 0644))

--- a/tests/websocket_pathparams_test.go
+++ b/tests/websocket_pathparams_test.go
@@ -421,7 +421,7 @@ func TestWebSocketPathParamsFullFlow(t *testing.T) {
 
 	t.Log("=== Testing WebSocket Path Parameters End-to-End ===")
 
-	// Step 1: Parse Glyph source with WebSocket path params
+	// Step 1: Parse GlyphLang source with WebSocket path params
 	t.Log("Step 1: Parsing source with path parameters...")
 	source := `
 @ ws /chat/:room {


### PR DESCRIPTION
Standardize the language name across the repo. The CLI printed `GLYPH` in caps, the docs said `Glyph`, and the README said `GlyphLang` - three spellings in one project. Also adds a trademark policy, since the name is the one thing the Apache license does not cover.

## Commit 1 - README, spec, llms.txt, TRADEMARK.md

- Bare "Glyph" to "GlyphLang" in `README.md` (7) and `docs/GLYPH_NOTATION_SPEC.md` (7, including the title).
- **`llms.txt` identity block.** Three lines in the header: symbol notation, no keyword declaration forms, single static binary from Releases. The middle sentence is what lets an agent notice it has drifted into some other syntax.
- **Makefile.** `head -n 35` to `head -n 38`, matching the longer preserved header. Without this the next `make llms.txt` truncates it.
- **`TRADEMARK.md`.** Apache-2.0 section 6 grants no rights to the name. Permissive by design: the CLI name, file extensions, and syntax are explicitly not marks, and nominative use - "works with GlyphLang", tutorials, unmodified redistribution - needs no permission.

## Commit 2 - CLI, remaining docs, editors, examples

- CLI help and command descriptions, REPL and debugger banners, generated context headers, validation messages.
- All remaining docs, package READMEs, deployment and test guides, editor integrations, examples, and scripts.
- VS Code: display strings and command titles only. Language id `glyph`, scope names, config keys, and command ids untouched. `GlyphLang` added as the first alias so the status bar shows it, with `Glyph` and `glyph` kept so existing fences and settings keep working.
- `docs/CLI.md` documented `--version` output as `Glyph version 0.3.2`; actual format is `GlyphLang v0.3.2`. Corrected.

## Deliberately left alone

- **The symbol sense stays lowercase** - "compact glyph syntax", "glyph symbols". These refer to the sigils, not the language.
- `glyph` CLI name, `.glyph`/`.glyphx`, `GLYPH_*` env vars, Go import paths.
- `class Glyph < Formula` in the Homebrew formula - Ruby requires the class name to match `glyph.rb`.
- **The installer's profile check.** It writes marker `# GlyphLang` but still greps for `Glyph`, so a profile written by an older installer is detected and re-running does not append a duplicate PATH entry.

## Scope note

The plan for commit 1 proposed a README line claiming compilation to Go, Python, TypeScript, Java, and Rust. Dropped - `glyph codegen` ships Python/FastAPI and TypeScript/Express only, and #297 has it producing non-runnable output. The README now says what is true: the language runs `.glyph` sources on its own Go runtime, distributed as a static binary.

## Verification

- `go build ./...`, `go vet ./...`, and the full `go test ./...` suite pass. Tests asserting on renamed output strings (context headers, REPL banners, MCP spec title) were updated with them.
- `glyph --help`, `--version`, and `validate` output inspected directly; `compact` still reads "compact glyph syntax".
- `examples/blog-api-complete/main.glyph` validates; the pre-commit example validation passes.
- llms.txt regeneration is idempotent - ran the recipe twice, identical sha256, which is what CI's `git diff --exit-code llms.txt` checks.
