### PR TITLE
fix: return 500 when a route fails, and repair redeclaring examples

### DIFF
--- a/cmd/glyph/handlers.go
+++ b/cmd/glyph/handlers.go
@@ -192,12 +192,7 @@ func createCompiledRouteHandler(route *ast.Route, bytecode []byte, wsHub *websoc
 		result, err := vmInstance.Execute(bytecode)
 		if err != nil {
 			// Log full error server-side, return generic message to client
-			printError(fmt.Errorf("bytecode execution failed: %w", err))
-			ctx.StatusCode = http.StatusInternalServerError
-			ctx.ResponseWriter.Header().Set("Content-Type", "application/json")
-			return json.NewEncoder(ctx.ResponseWriter).Encode(map[string]interface{}{
-				"error": "Internal server error",
-			})
+			return writeInternalError(ctx, fmt.Errorf("bytecode execution failed: %w", err))
 		}
 
 		// Unwrap status-carrying results from guards and `> value :: N`
@@ -240,13 +235,7 @@ func createRouteHandler(route *ast.Route, interp *interpreter.Interpreter) serve
 		// Execute route body using the interpreter
 		response, err := executeRoute(route, ctx, interp)
 		if err != nil {
-			// Log full error server-side, return generic message to client
-			printError(fmt.Errorf("route execution error: %w", err))
-			ctx.StatusCode = http.StatusInternalServerError
-			ctx.ResponseWriter.Header().Set("Content-Type", "application/json")
-			return json.NewEncoder(ctx.ResponseWriter).Encode(map[string]interface{}{
-				"error": "Internal server error",
-			})
+			return writeInternalError(ctx, fmt.Errorf("route execution error: %w", err))
 		}
 
 		// Check for redirect response (Location header set by interpreter)
@@ -635,6 +624,20 @@ func printWarning(msg string) {
 
 func printError(err error) {
 	errorColor.Printf("[ERROR] %s\n", err.Error())
+}
+
+// writeInternalError logs the full error server-side and sends a generic 500 to
+// the client. WriteHeader must be called before the body is written: writing
+// first makes net/http commit an implicit 200, so a failed route would report
+// success to the caller.
+func writeInternalError(ctx *server.Context, err error) error {
+	printError(err)
+	ctx.StatusCode = http.StatusInternalServerError
+	ctx.ResponseWriter.Header().Set("Content-Type", "application/json")
+	ctx.ResponseWriter.WriteHeader(http.StatusInternalServerError)
+	return json.NewEncoder(ctx.ResponseWriter).Encode(map[string]interface{}{
+		"error": "Internal server error",
+	})
 }
 
 func printRequest(method, path string) {

--- a/cmd/glyph/handlers_error_test.go
+++ b/cmd/glyph/handlers_error_test.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/glyphlang/glyph/pkg/ast"
+	"github.com/glyphlang/glyph/pkg/interpreter"
+	"github.com/glyphlang/glyph/pkg/server"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRouteRuntimeErrorReturns500 verifies that a route failing at runtime
+// reports HTTP 500 rather than 200. Writing the JSON body without calling
+// WriteHeader first makes net/http commit an implicit 200, so a crashed
+// handler used to look like a success to every client checking status codes.
+func TestRouteRuntimeErrorReturns500(t *testing.T) {
+	// Redeclaring a binding in the same scope parses and typechecks, then
+	// fails during execution - the same shape as the bug found in
+	// examples/todo-api.
+	src := `@ GET /api/boom {
+  $ count = 0
+  $ count = 1
+  > {count: count}
+}`
+	module, err := parseSource(src)
+	require.NoError(t, err, "parse source")
+
+	var route *ast.Route
+	for _, item := range module.Items {
+		if r, ok := item.(*ast.Route); ok {
+			route = r
+			break
+		}
+	}
+	require.NotNil(t, route, "no route found in source")
+
+	req := httptest.NewRequest("GET", "/api/boom", nil)
+	rec := httptest.NewRecorder()
+	ctx := &server.Context{
+		Request:        req,
+		ResponseWriter: rec,
+		PathParams:     map[string]string{},
+		StatusCode:     http.StatusOK,
+	}
+
+	handler := createRouteHandler(route, interpreter.NewInterpreter())
+	require.NoError(t, handler(ctx), "handler should write a response, not return an error")
+
+	assert.Equal(t, http.StatusInternalServerError, rec.Code, "body=%s", rec.Body.String())
+	assert.Equal(t, "application/json", rec.Header().Get("Content-Type"))
+
+	var body map[string]interface{}
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&body))
+	assert.Equal(t, "Internal server error", body["error"])
+}

--- a/examples/blog-api-complete/main.glyph
+++ b/examples/blog-api-complete/main.glyph
@@ -148,7 +148,7 @@
   } else {
     for post in all_posts {
       if post.published == published {
-        $ filtered_posts = filtered_posts + [post]
+        filtered_posts = filtered_posts + [post]
       }
     }
   }

--- a/examples/cart-api/main.glyph
+++ b/examples/cart-api/main.glyph
@@ -76,7 +76,7 @@
     $ allProducts = db.products.filter("category", query.category)
     $ category = query.category
   } else {
-    $ allProducts = db.products.all()
+    allProducts = db.products.all()
   }
 
   $ total = allProducts.length()
@@ -417,12 +417,12 @@
           if discount.type == "percentage" {
             $ discountAmount = cart.subtotal * (discount.value / 100.0)
           } else {
-            $ discountAmount = discount.value
+            discountAmount = discount.value
           }
 
           # Ensure discount doesn't exceed subtotal
           if discountAmount > cart.subtotal {
-            $ discountAmount = cart.subtotal
+            discountAmount = cart.subtotal
           }
 
           $ cart.discount = discountAmount

--- a/examples/cli-demo/main.glyph
+++ b/examples/cli-demo/main.glyph
@@ -23,7 +23,7 @@
   if formal {
     $ msg = "Good day, " + name + ". How may I assist you?"
   } else {
-    $ msg = "Hey " + name + "!"
+    msg = "Hey " + name + "!"
   }
   > {greeting: msg}
 }

--- a/examples/collections-demo/main.glyph
+++ b/examples/collections-demo/main.glyph
@@ -130,7 +130,7 @@
     $ limit = 20
   }
   if limit > 100 {
-    $ limit = 100
+    limit = 100
   }
 
   $ startIndex = (page - 1) * limit
@@ -248,16 +248,16 @@
     $ categoryList = categoryList + [{name: "electronics", count: electronicsCount, total_value: electronicsValue}]
   }
   if clothingCount > 0 {
-    $ categoryList = categoryList + [{name: "clothing", count: clothingCount, total_value: clothingValue}]
+    categoryList = categoryList + [{name: "clothing", count: clothingCount, total_value: clothingValue}]
   }
   if foodCount > 0 {
-    $ categoryList = categoryList + [{name: "food", count: foodCount, total_value: foodValue}]
+    categoryList = categoryList + [{name: "food", count: foodCount, total_value: foodValue}]
   }
   if homeCount > 0 {
-    $ categoryList = categoryList + [{name: "home", count: homeCount, total_value: homeValue}]
+    categoryList = categoryList + [{name: "home", count: homeCount, total_value: homeValue}]
   }
   if otherCount > 0 {
-    $ categoryList = categoryList + [{name: "other", count: otherCount, total_value: otherValue}]
+    categoryList = categoryList + [{name: "other", count: otherCount, total_value: otherValue}]
   }
 
   > {
@@ -420,7 +420,7 @@
                     quantity: newQuantity
                 }]
               } else {
-                $ newItems = newItems + [item]
+                newItems = newItems + [item]
               }
               $ itemIndex = itemIndex + 1
             }
@@ -538,7 +538,7 @@
         }
       }
       if categoryMatch == false {
-        $ matches = false
+        matches = false
       }
     }
 
@@ -553,14 +553,14 @@
         }
       }
       if tagMatch == false {
-        $ matches = false
+        matches = false
       }
     }
 
     # In stock filter
     if matches == true && inStockOnly == true {
       if product.inventory < 1 || product.active == false {
-        $ matches = false
+        matches = false
       }
     }
 

--- a/examples/defaults-demo/main.glyph
+++ b/examples/defaults-demo/main.glyph
@@ -174,7 +174,7 @@
   if formal {
     $ msg = "Good day, " + name + "."
   } else {
-    $ msg = "Hey " + name + "!"
+    msg = "Hey " + name + "!"
   }
   > {greeting: msg}
 }

--- a/examples/feature-showcase/main.glyph
+++ b/examples/feature-showcase/main.glyph
@@ -293,7 +293,7 @@ type ChatMessage {
         if age < 65 {
           $ category = "adult"
         } else {
-          $ category = "senior"
+          category = "senior"
         }
       }
     }
@@ -316,7 +316,7 @@ type ChatMessage {
       $ hasAccess = true
       $ level = "partial-access"
     } else {
-      $ level = "restricted"
+      level = "restricted"
     }
   }
 
@@ -443,24 +443,24 @@ type ChatMessage {
       $ can_cancel = true
     }
     case "processing" {
-      $ status_message = "Your order is being prepared"
-      $ can_cancel = true
+      status_message = "Your order is being prepared"
+      can_cancel = true
     }
     case "shipped" {
-      $ status_message = "Your order is on its way"
-      $ can_cancel = false
+      status_message = "Your order is on its way"
+      can_cancel = false
     }
     case "delivered" {
-      $ status_message = "Your order has been delivered"
-      $ can_cancel = false
+      status_message = "Your order has been delivered"
+      can_cancel = false
     }
     case "cancelled" {
-      $ status_message = "This order was cancelled"
-      $ can_cancel = false
+      status_message = "This order was cancelled"
+      can_cancel = false
     }
     default {
-      $ status_message = "Unknown status"
-      $ can_cancel = false
+      status_message = "Unknown status"
+      can_cancel = false
     }
   }
 
@@ -477,16 +477,16 @@ type ChatMessage {
       $ grade = "A"
     }
     case 80 {
-      $ grade = "B"
+      grade = "B"
     }
     case 70 {
-      $ grade = "C"
+      grade = "C"
     }
     case 60 {
-      $ grade = "D"
+      grade = "D"
     }
     default {
-      $ grade = "F"
+      grade = "F"
     }
   }
 
@@ -1035,7 +1035,7 @@ type ChatMessage {
       if subtotal < 100 {
         $ shipping = 4.99
       } else {
-        $ shipping = 0.0
+        shipping = 0.0
       }
     }
 
@@ -1048,14 +1048,14 @@ type ChatMessage {
           $ discount = subtotal * 0.10
         }
         case "SAVE20" {
-          $ discount = subtotal * 0.20
+          discount = subtotal * 0.20
         }
         case "FREESHIP" {
-          $ discount = shipping
+          discount = shipping
           $ shipping = 0.0
         }
         default {
-          $ discount = 0.0
+          discount = 0.0
         }
       }
     }

--- a/examples/switch_test.glyph
+++ b/examples/switch_test.glyph
@@ -40,13 +40,13 @@
       $ grade = "A"
     }
     case 80 {
-      $ grade = "B"
+      grade = "B"
     }
     case 70 {
-      $ grade = "C"
+      grade = "C"
     }
     default {
-      $ grade = "F"
+      grade = "F"
     }
   }
   > {grade: grade, score: score}

--- a/examples/todo-api/main.glyph
+++ b/examples/todo-api/main.glyph
@@ -55,10 +55,6 @@
   $ total = todos.length()
 
   # Count completed and pending
-  $ completed = 0
-  $ pending = 0
-
-  # In a real implementation, this would iterate through todos
   $ completed = db.todos.count("completed", true)
   $ pending = db.todos.count("completed", false)
 

--- a/examples/validation-demo/main.glyph
+++ b/examples/validation-demo/main.glyph
@@ -77,72 +77,72 @@
 
   # Validate email - required, valid format, unique
   if input.email == null || input.email == "" {
-    $ errors = errors + [{
+    errors = errors + [{
         field: "email",
         message: "Email is required",
         code: "REQUIRED"
     }]
-    $ hasErrors = true
+    hasErrors = true
   } else {
     # Check basic email format (contains @ and .)
     $ emailValid = input.email.contains("@")
     if emailValid == false {
-      $ errors = errors + [{
+      errors = errors + [{
           field: "email",
           message: "Invalid email format",
           code: "INVALID_FORMAT"
       }]
-      $ hasErrors = true
+      hasErrors = true
     } else {
       # Check uniqueness
       $ existingEmail = db.users.findOne("email", input.email)
       if existingEmail != null {
-        $ errors = errors + [{
+        errors = errors + [{
             field: "email",
             message: "Email already registered",
             code: "ALREADY_EXISTS"
         }]
-        $ hasErrors = true
+        hasErrors = true
       }
     }
   }
 
   # Validate password - required, minimum 8 chars
   if input.password == null || input.password == "" {
-    $ errors = errors + [{
+    errors = errors + [{
         field: "password",
         message: "Password is required",
         code: "REQUIRED"
     }]
-    $ hasErrors = true
+    hasErrors = true
   } else {
     if input.password.length() < 8 {
-      $ errors = errors + [{
+      errors = errors + [{
           field: "password",
           message: "Password must be at least 8 characters",
           code: "MIN_LENGTH"
       }]
-      $ hasErrors = true
+      hasErrors = true
     }
   }
 
   # Validate age - optional, but if provided must be 0-150
   if input.age != null {
     if input.age < 0 {
-      $ errors = errors + [{
+      errors = errors + [{
           field: "age",
           message: "Age cannot be negative",
           code: "MIN_VALUE"
       }]
-      $ hasErrors = true
+      hasErrors = true
     } else {
       if input.age > 150 {
-        $ errors = errors + [{
+        errors = errors + [{
             field: "age",
             message: "Age cannot exceed 150",
             code: "MAX_VALUE"
         }]
-        $ hasErrors = true
+        hasErrors = true
       }
     }
   }
@@ -150,12 +150,12 @@
   # Validate phone - optional, but if provided must be valid format
   if input.phone != null && input.phone != "" {
     if input.phone.length() < 10 || input.phone.length() > 15 {
-      $ errors = errors + [{
+      errors = errors + [{
           field: "phone",
           message: "Phone must be 10-15 digits",
           code: "INVALID_FORMAT"
       }]
-      $ hasErrors = true
+      hasErrors = true
     }
   }
 
@@ -242,24 +242,24 @@
     # Validate age if provided
     if input.age != null {
       if input.age < 0 || input.age > 150 {
-        $ errors = errors + [{
+        errors = errors + [{
             field: "age",
             message: "Age must be between 0 and 150",
             code: "OUT_OF_RANGE"
         }]
-        $ hasErrors = true
+        hasErrors = true
       }
     }
 
     # Validate phone if provided
     if input.phone != null && input.phone != "" {
       if input.phone.length() < 10 || input.phone.length() > 15 {
-        $ errors = errors + [{
+        errors = errors + [{
             field: "phone",
             message: "Phone must be 10-15 digits",
             code: "INVALID_FORMAT"
         }]
-        $ hasErrors = true
+        hasErrors = true
       }
     }
 
@@ -337,20 +337,20 @@
 
   # Validate price - required, must be positive
   if input.price == null {
-    $ errors = errors + [{
+    errors = errors + [{
         field: "price",
         message: "Price is required",
         code: "REQUIRED"
     }]
-    $ hasErrors = true
+    hasErrors = true
   } else {
     if input.price <= 0 {
-      $ errors = errors + [{
+      errors = errors + [{
           field: "price",
           message: "Price must be greater than 0",
           code: "MIN_VALUE"
       }]
-      $ hasErrors = true
+      hasErrors = true
     } else {
       if input.price > 999999.99 {
         $ errors = errors + [{
@@ -365,20 +365,20 @@
 
   # Validate quantity - required, non-negative integer
   if input.quantity == null {
-    $ errors = errors + [{
+    errors = errors + [{
         field: "quantity",
         message: "Quantity is required",
         code: "REQUIRED"
     }]
-    $ hasErrors = true
+    hasErrors = true
   } else {
     if input.quantity < 0 {
-      $ errors = errors + [{
+      errors = errors + [{
           field: "quantity",
           message: "Quantity cannot be negative",
           code: "MIN_VALUE"
       }]
-      $ hasErrors = true
+      hasErrors = true
     }
   }
 
@@ -386,46 +386,46 @@
   $ categoryValid = false
 
   if input.category == null || input.category == "" {
-    $ errors = errors + [{
+    errors = errors + [{
         field: "category",
         message: "Category is required",
         code: "REQUIRED"
     }]
-    $ hasErrors = true
+    hasErrors = true
   } else {
     if input.category == "electronics" || input.category == "clothing" || input.category == "food" || input.category == "home" || input.category == "other" {
       $ categoryValid = true
     }
 
     if categoryValid == false {
-      $ errors = errors + [{
+      errors = errors + [{
           field: "category",
           message: "Invalid category. Must be: electronics, clothing, food, home, or other",
           code: "INVALID_VALUE"
       }]
-      $ hasErrors = true
+      hasErrors = true
     }
   }
 
   # Validate SKU if provided - must be alphanumeric and 8-20 chars
   if input.sku != null && input.sku != "" {
     if input.sku.length() < 8 || input.sku.length() > 20 {
-      $ errors = errors + [{
+      errors = errors + [{
           field: "sku",
           message: "SKU must be 8-20 characters",
           code: "LENGTH_ERROR"
       }]
-      $ hasErrors = true
+      hasErrors = true
     } else {
       # Check uniqueness
       $ existingSku = db.products.findOne("sku", input.sku)
       if existingSku != null {
-        $ errors = errors + [{
+        errors = errors + [{
             field: "sku",
             message: "SKU already exists",
             code: "ALREADY_EXISTS"
         }]
-        $ hasErrors = true
+        hasErrors = true
       }
     }
   }
@@ -495,24 +495,24 @@
   # Validate page number if provided
   if input.page != null {
     if input.page < 1 {
-      $ errors = errors + [{
+      errors = errors + [{
           field: "page",
           message: "Page number must be at least 1",
           code: "MIN_VALUE"
       }]
-      $ hasErrors = true
+      hasErrors = true
     }
   }
 
   # Validate limit if provided
   if input.limit != null {
     if input.limit < 1 || input.limit > 100 {
-      $ errors = errors + [{
+      errors = errors + [{
           field: "limit",
           message: "Limit must be between 1 and 100",
           code: "OUT_OF_RANGE"
       }]
-      $ hasErrors = true
+      hasErrors = true
     }
   }
 


### PR DESCRIPTION
Two bugs found while smoke-testing the examples ahead of building a showcase project.

## 1. A failing route answered HTTP 200

```
$ curl -w "status=%{http_code}" localhost:8099/api/todos
{"error":"Internal server error"}
status=200          <- should be 500
```

Both error paths in `cmd/glyph/handlers.go` (compiled at :195, interpreted at :238) set `ctx.StatusCode = 500` and then wrote the JSON body directly. `net/http` commits an implicit `WriteHeader(200)` on the first write, so the status was never sent. Any client checking status codes read a crashed handler as success - including retry logic, uptime monitors, and generated API clients.

Both sites now call `writeInternalError`, which sets the header before the body. The outer handler wrapper at :437 already did this correctly and is unchanged; the helper means the three cannot drift apart again.

Verified against a running server, interpreter mode: `status=500` where it was 200.

## 2. Nine examples redeclared variables

`$` is a declaration. Reassignment is the bare form:

```glyph
$ count = 0     # declare
count = 1       # reassign
```

Nine examples used `$` for both, so those routes failed at runtime with `cannot redeclare variable 'x' in the same scope`. `examples/todo-api` was the one I hit first - `GET /api/todos` 500'd while `POST` worked. It now returns todos with counts, verified end to end against a running server.

Fixed with a scope-aware scan (same brace depth, same route) rather than a blind find-and-replace, so `$ obj.field = expr` - which legitimately keeps the sigil - was left alone.

## Why CI did not catch either

- `glyph validate` does not run the compiler's semantic pass. All 43 example files validate clean, before and after this change; the redeclaration only surfaces when the route executes.
- Only `hello-world` and `rest-api` are exercised by tests. CI never runs the other 32 example projects.
- Compiled mode does catch redeclaration at startup - but any route injecting a provider (`% db: Database`) runs interpreted, where it only fails per-request.

Both gaps are worth closing separately; this PR fixes the defects, not the process.

## Verification

- New `TestRouteRuntimeErrorReturns500` asserts 500 and the JSON body. Confirmed it fails (`actual: 200`) when the `WriteHeader` line is removed, so it is not a vacuous test.
- Full `go test ./...` and `go vet ./...` pass.
- All 43 example files validate.
- Live server checks: `todo-api` POST then GET returns data with zero errors logged; a deliberately failing interpreted route returns 500.
