### PR TITLE
feat: make the LLM provider usable and add an example that uses it

### DIFF
--- a/cmd/glyph/handlers.go
+++ b/cmd/glyph/handlers.go
@@ -22,6 +22,7 @@ import (
 	"github.com/glyphlang/glyph/pkg/compiler"
 	"github.com/glyphlang/glyph/pkg/database"
 	"github.com/glyphlang/glyph/pkg/interpreter"
+	"github.com/glyphlang/glyph/pkg/llm"
 	"github.com/glyphlang/glyph/pkg/parser"
 	"github.com/glyphlang/glyph/pkg/server"
 	"github.com/glyphlang/glyph/pkg/vm"
@@ -52,6 +53,14 @@ func newConfiguredInterpreter() *interpreter.Interpreter {
 	interp := interpreter.NewInterpreter()
 	mockDB := database.NewMockDatabase()
 	interp.SetDatabaseHandler(mockDB)
+
+	// The LLM provider is configured from the environment so a .glyph file
+	// stays portable across providers and carries no credentials.
+	if handler, err := newLLMHandler(); err != nil {
+		printWarning(err.Error())
+	} else if handler != nil {
+		interp.SetLLMHandler(handler)
+	}
 
 	// Set up the parse function for module resolution
 	interp.GetModuleResolver().SetParseFunc(func(source string) (*ast.Module, error) {
@@ -624,6 +633,36 @@ func printWarning(msg string) {
 
 func printError(err error) {
 	errorColor.Printf("[ERROR] %s\n", err.Error())
+}
+
+// llmEnvHint lists the environment variables that configure `% x: LLM`.
+const llmEnvHint = "set GLYPH_LLM_PROVIDER (anthropic|openai|ollama) and GLYPH_LLM_API_KEY"
+
+// newLLMHandler builds the LLM provider handler from the environment.
+// Returns (nil, nil) when GLYPH_LLM_PROVIDER is unset: a program that never
+// injects LLM should not be forced to configure one.
+func newLLMHandler() (*llm.Handler, error) {
+	provider := strings.ToLower(strings.TrimSpace(os.Getenv("GLYPH_LLM_PROVIDER")))
+	if provider == "" {
+		return nil, nil
+	}
+
+	switch llm.Provider(provider) {
+	case llm.ProviderAnthropic, llm.ProviderOpenAI, llm.ProviderOllama:
+	default:
+		return nil, fmt.Errorf("unknown GLYPH_LLM_PROVIDER %q: expected anthropic, openai, or ollama", provider)
+	}
+
+	// Ollama runs locally and takes no credential; the hosted providers do.
+	apiKey := os.Getenv("GLYPH_LLM_API_KEY")
+	if apiKey == "" && llm.Provider(provider) != llm.ProviderOllama {
+		return nil, fmt.Errorf("GLYPH_LLM_PROVIDER=%s but GLYPH_LLM_API_KEY is empty: LLM routes will fail", provider)
+	}
+
+	if baseURL := os.Getenv("GLYPH_LLM_BASE_URL"); baseURL != "" {
+		return llm.NewHandlerWithBaseURL(provider, apiKey, baseURL)
+	}
+	return llm.NewHandler(provider, apiKey), nil
 }
 
 // writeInternalError logs the full error server-side and sends a generic 500 to

--- a/cmd/glyph/routes.go
+++ b/cmd/glyph/routes.go
@@ -14,6 +14,25 @@ import (
 	"github.com/glyphlang/glyph/pkg/websocket"
 )
 
+// moduleInjectsLLM reports whether any route in the module injects an LLM provider.
+func moduleInjectsLLM(module *ast.Module) bool {
+	for _, item := range module.Items {
+		route, ok := item.(*ast.Route)
+		if !ok {
+			continue
+		}
+		for _, injection := range route.Injections {
+			if _, isLLM := injection.Type.(ast.LLMType); isLLM {
+				return true
+			}
+			if named, ok := injection.Type.(ast.NamedType); ok && named.Name == "LLM" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // setupRoutes handles the common logic of determining execution mode, compiling routes,
 // and setting up the router. Used by both startServer and startDevServerInternal.
 // filePath is the path to the source file, used for resolving relative module imports.
@@ -24,25 +43,22 @@ func setupRoutes(module *ast.Module, filePath string, forceInterpreter ...bool) 
 	}
 	compiledRoutes = make(map[string][]byte)
 
-	// Check if any route has database injection - VM doesn't support db method calls
+	// Any provider injection forces interpreter mode: the VM cannot execute
+	// provider method calls, so a compiled route fails at request time with
+	// "undefined function". This covers Database, Redis, MongoDB, LLM, HTTP
+	// and custom providers alike.
 	for _, item := range module.Items {
-		if route, ok := item.(*ast.Route); ok {
-			for _, injection := range route.Injections {
-				if _, isDB := injection.Type.(ast.DatabaseType); isDB {
-					printInfo("Routes use database injection, using interpreter mode")
-					useCompiler = false
-					break
-				}
-				if named, ok := injection.Type.(ast.NamedType); ok && named.Name == "Database" {
-					printInfo("Routes use database injection, using interpreter mode")
-					useCompiler = false
-					break
-				}
-			}
-			if !useCompiler {
-				break
-			}
+		if route, ok := item.(*ast.Route); ok && len(route.Injections) > 0 {
+			printInfo("Routes use provider injection, using interpreter mode")
+			useCompiler = false
+			break
 		}
+	}
+
+	// Warn early when an LLM route has no provider configured, rather than
+	// letting every request fail with an opaque "undefined object" error.
+	if os.Getenv("GLYPH_LLM_PROVIDER") == "" && moduleInjectsLLM(module) {
+		printWarning("routes inject LLM but no provider is configured: " + llmEnvHint)
 	}
 
 	// Try to compile routes if using compiler mode

--- a/examples/llm-api/main.glyph
+++ b/examples/llm-api/main.glyph
@@ -1,0 +1,118 @@
+# Document summarizer with an AI-generated Q&A endpoint.
+#
+# Shows the LLM provider (% ai: LLM) alongside the database provider in the
+# same file: store a document, summarize it with a model, ask questions
+# against it. Routes, types, validation, auth and the model call live in one
+# file with no client library and no glue code.
+#
+# Configure the provider before running:
+#   GLYPH_LLM_PROVIDER=anthropic|openai|ollama
+#   GLYPH_LLM_API_KEY=<key>          # not needed for ollama
+#   GLYPH_LLM_BASE_URL=<url>         # optional, for self-hosted or proxied
+#
+#   glyph run examples/llm-api/main.glyph --port 8080
+
+: Document {
+  id: int!
+  title: str!
+  body: str!
+  summary: str?
+  created_at: int?
+}
+
+: CreateDocumentRequest {
+  title: str!
+  body: str!
+}
+
+: SummaryResponse {
+  id: int!
+  title: str!
+  summary: str!
+  model: str!
+}
+
+: AnswerResponse {
+  question: str!
+  answer: str!
+  document_id: int!
+}
+
+# Store a document. The summary is filled in by POST /documents/:id/summarize.
+@ POST /documents -> Document {
+  + ratelimit(60/min)
+  < input: CreateDocumentRequest
+  % db: Database
+
+  $ doc = db.documents.Create(input)
+  > doc :: 201
+}
+
+@ GET /documents/:id -> Document | Error {
+  % db: Database
+
+  $ doc = db.documents.Get(id)
+  ? doc != null :: 404 "document not found"
+  > doc
+}
+
+# Summarize a stored document and persist the result.
+@ POST /documents/:id/summarize -> SummaryResponse | Error {
+  + auth(apikey)
+  + ratelimit(20/min)
+  % db: Database
+  % ai: LLM
+
+  $ doc = db.documents.Get(id)
+  ? doc != null :: 404 "document not found"
+
+  $ reply = ai.Complete({
+    model: "claude-opus-5",
+    max_tokens: 300,
+    messages: [
+      {role: "user", content: "Summarize the following document in two sentences.\n\n" + doc.body}
+    ]
+  })
+
+  ? reply.content != null :: 502 "model returned no content"
+
+  $ updated = db.documents.Update(id, {summary: reply.content})
+
+  > {
+    id: doc.id,
+    title: doc.title,
+    summary: reply.content,
+    model: reply.model
+  }
+}
+
+# Answer a question grounded in one stored document.
+@ POST /documents/:id/ask -> AnswerResponse | Error {
+  + auth(apikey)
+  + ratelimit(20/min)
+  < input: any
+  % db: Database
+  % ai: LLM
+
+  ? input.question != null :: 400 "question is required"
+
+  $ doc = db.documents.Get(id)
+  ? doc != null :: 404 "document not found"
+
+  $ reply = ai.Complete({
+    model: "claude-opus-5",
+    max_tokens: 500,
+    temperature: 0.2,
+    messages: [
+      {role: "user", content: "Answer using only the document below. If the answer is not in it, say so.\n\nDocument:\n" + doc.body + "\n\nQuestion: " + input.question}
+    ]
+  })
+
+  ? reply.content != null :: 502 "model returned no content"
+
+  > {
+    question: input.question,
+    answer: reply.content,
+    document_id: doc.id
+  }
+}

--- a/pkg/database/handler.go
+++ b/pkg/database/handler.go
@@ -240,13 +240,27 @@ func (m *MockTableHandler) All() []interface{} {
 	return result
 }
 
+// sameID reports whether a stored record id and a lookup id identify the same
+// record. Ids reach a handler from path parameters as strings while records
+// store them as numbers, so comparing the interface values directly never
+// matches and every lookup by id returns nothing.
+func sameID(stored, lookup interface{}) bool {
+	if stored == nil || lookup == nil {
+		return false
+	}
+	if stored == lookup {
+		return true
+	}
+	return fmt.Sprint(stored) == fmt.Sprint(lookup)
+}
+
 // Get retrieves a record by ID
 func (m *MockTableHandler) Get(id interface{}) interface{} {
 	m.db.mu.RLock()
 	defer m.db.mu.RUnlock()
 
 	for _, record := range m.db.data[m.name] {
-		if record["id"] == id {
+		if sameID(record["id"], id) {
 			return record
 		}
 	}
@@ -273,7 +287,7 @@ func (m *MockTableHandler) Update(id interface{}, data map[string]interface{}) m
 	defer m.db.mu.Unlock()
 
 	for i, record := range m.db.data[m.name] {
-		if record["id"] == id {
+		if sameID(record["id"], id) {
 			// Merge data
 			for k, v := range data {
 				record[k] = v
@@ -291,7 +305,7 @@ func (m *MockTableHandler) Delete(id interface{}) bool {
 	defer m.db.mu.Unlock()
 
 	for i, record := range m.db.data[m.name] {
-		if record["id"] == id {
+		if sameID(record["id"], id) {
 			m.db.data[m.name] = append(m.db.data[m.name][:i], m.db.data[m.name][i+1:]...)
 			return true
 		}

--- a/pkg/database/mock_id_test.go
+++ b/pkg/database/mock_id_test.go
@@ -1,0 +1,53 @@
+package database
+
+import "testing"
+
+// TestMockLookupByStringID covers the shape every route hits: a record created
+// with a numeric id, then fetched with the id taken from a path parameter,
+// which arrives as a string. Comparing the interface values directly never
+// matched, so get/update/delete by id silently returned nothing.
+func TestMockLookupByStringID(t *testing.T) {
+	db := NewMockDatabase()
+	table := db.Table("documents")
+
+	created := table.Create(map[string]interface{}{"title": "ponytail"})
+	if created["id"] == nil {
+		t.Fatal("Create did not assign an id")
+	}
+
+	got := table.Get("1")
+	if got == nil {
+		t.Fatal("Get(\"1\") returned nil for the record created with id 1")
+	}
+	if record, ok := got.(map[string]interface{}); !ok || record["title"] != "ponytail" {
+		t.Fatalf("Get returned the wrong record: %#v", got)
+	}
+
+	if updated := table.Update("1", map[string]interface{}{"title": "updated"}); updated == nil {
+		t.Fatal("Update(\"1\") did not find the record")
+	}
+	if record, ok := table.Get(int64(1)).(map[string]interface{}); !ok || record["title"] != "updated" {
+		t.Fatalf("Get(int64) did not see the update: %#v", table.Get(int64(1)))
+	}
+
+	if !table.Delete("1") {
+		t.Fatal("Delete(\"1\") did not find the record")
+	}
+	if table.Get("1") != nil {
+		t.Fatal("record still present after Delete")
+	}
+}
+
+// TestSameIDRejectsNil guards the nil case: a record without an id must not
+// match a nil lookup just because both format identically.
+func TestSameIDRejectsNil(t *testing.T) {
+	if sameID(nil, nil) {
+		t.Error("sameID(nil, nil) must be false")
+	}
+	if sameID(int64(1), nil) {
+		t.Error("sameID(1, nil) must be false")
+	}
+	if !sameID(int64(7), "7") {
+		t.Error("sameID(int64(7), \"7\") must be true")
+	}
+}


### PR DESCRIPTION
Stacked on #305 - review that one first; GitHub will retarget this to main when it merges.

`% ai: LLM` validated, typechecked and compiled, then failed on every request:

```
[POST] /ask [ERROR] bytecode execution failed: undefined function: ai.Complete
```

Two independent causes, both fixed here, plus a third bug found while verifying.

## 1. No handler was ever constructed

`SetLLMHandler`, `SetRedisHandler`, `SetMongoDBHandler` and `SetHTTPHandler` are defined and called from nowhere. The only provider with a runtime binding was Database, wired to `NewMockDatabase()` in `newConfiguredInterpreter`.

The LLM handler is now built there too, from the environment so a `.glyph` file carries no credentials and stays portable:

```
GLYPH_LLM_PROVIDER   anthropic | openai | ollama
GLYPH_LLM_API_KEY    required except for ollama
GLYPH_LLM_BASE_URL   optional, for self-hosted or proxied endpoints
```

Unset means unset - a program that never injects LLM is not forced to configure one. Three failure modes now warn at startup instead of failing per request: unknown provider, missing key, and a module that injects LLM with nothing configured.

## 2. Mode selection only knew about Database

`setupRoutes` fell back to interpreter mode solely for `Database` injections, so LLM routes stayed compiled where the VM cannot execute any provider call. The check now covers any injection - Database, Redis, MongoDB, LLM, HTTP and custom providers alike - which is the honest rule, since the VM supports none of them.

## 3. Lookup by id never matched (pre-existing, repo-wide)

Found while testing the example. `MockTableHandler` stores ids as `int64` and compares with `==` against a path parameter, which arrives as a string, so `Get`, `Update` and `Delete` by id always missed:

```
$ curl localhost:8087/api/todos/1        # before
{"code":"NOT_FOUND","message":"Todo not found","success":false}

$ curl localhost:8084/api/todos/1        # after
{"id":1,"title":"x","priority":"high",...}
```

Every example that fetches a record by id was silently broken. All three call sites now route through one `sameID` helper.

## The example

`examples/llm-api/main.glyph` - store a document, summarize it with a model, ask questions grounded in it. Database and LLM providers in the same file, with API-key auth, rate limits and guards, and no client library or glue code.

## Verification

Run against a stub provider so it needs no API key:

| request | result |
|---|---|
| `POST /documents` | 201, id assigned |
| `GET /documents/1` | 200, record returned |
| `POST /documents/1/summarize` | 200, model called, summary persisted |
| `POST /documents/1/ask` | 200, grounded answer |
| `POST /documents/99/summarize` | 404 from the guard |

Zero errors logged. `todo-api` get-by-id verified fixed on a live server. New `TestMockLookupByStringID` covers create-then-fetch across `int64`/string and the nil case. Full `go test ./...` and `go vet ./...` pass; all 44 example files validate.

## Not covered

Redis, MongoDB and HTTP handlers are still never constructed, so those examples remain broken at runtime. Same shape of fix, but each needs a live service to verify - worth its own issue.
