### PR TITLE
fix: validate the compiler's semantic pass and document reassignment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -142,7 +142,7 @@ dev:
 
 # Regenerate llms.txt (AI agent primer served at glyphlang.dev/llms.txt)
 llms.txt:
-	head -n 38 llms.txt > llms_header.tmp
+	head -n 39 llms.txt > llms_header.tmp
 	cat llms_header.tmp docs/GLYPH_NOTATION_SPEC.md > llms.txt
 	rm llms_header.tmp
 .PHONY: llms.txt

--- a/docs/GLYPH_NOTATION_SPEC.md
+++ b/docs/GLYPH_NOTATION_SPEC.md
@@ -297,7 +297,48 @@ route GET /users/:id { use db: Database let user = db.users.Get(id) return user 
 
 Both are semantically identical and produce the same AST/IR.
 
-## 9. Control Flow
+## 9. Bindings and Reassignment
+
+`$` declares a new binding. Reassigning an existing one drops the sigil:
+
+```glyph
+$ total = 0        # declare
+total = total + 1  # reassign
+```
+
+Declaring the same name twice in one scope is an error - `cannot redeclare
+variable 'total' in the same scope` - so a running total, an accumulator, or a
+value refined by a later step uses the bare form after its first declaration:
+
+```glyph
+@ GET /api/cart/:id {
+  % db: Database
+
+  $ cart = db.carts.Get(id)
+  $ total = 0
+
+  for item in cart.items {
+    total = total + item.price
+  }
+
+  > {cart: cart, total: total}
+}
+```
+
+Path and query parameters are already bound by the route pattern, so they
+cannot be redeclared either. Assign to a different name instead:
+
+```glyph
+@ GET /api/factorial/:n {
+  $ limit = parseInt(n)   # not: $ n = parseInt(n)
+  ...
+}
+```
+
+Field assignment keeps the sigil, since it writes through an existing binding
+rather than introducing a name: `$ user.name = "Ada"`.
+
+## 10. Control Flow
 
 ```glyph
 # Conditionals
@@ -322,7 +363,7 @@ switch value {
 }
 ```
 
-## 10. Grammar (EBNF Summary)
+## 11. Grammar (EBNF Summary)
 
 ```ebnf
 program     = { item } ;
@@ -345,7 +386,8 @@ input_decl  = "<" IDENT ":" type ;
 validate    = "?" IDENT "(" [ args ] ")" ;
 guard       = "?" expr "::" INTEGER [ STRING ] ;
 statement   = assign | reassign | return | if | for | while | switch | expr_stmt ;
-assign      = "$" IDENT "=" expr ;
+assign      = "$" IDENT [ "." IDENT ] "=" expr ;
+reassign    = IDENT "=" expr ;
 return      = ">" expr [ "::" INTEGER ] ;
 
 type        = "int" | "float" | "str" | "bool" | "any"
@@ -357,7 +399,7 @@ type        = "int" | "float" | "str" | "bool" | "any"
 method      = "GET" | "POST" | "PUT" | "DELETE" | "PATCH" | "ws" | "sse" ;
 ```
 
-## 11. Design Principles
+## 12. Design Principles
 
 1. **Intent over implementation**: GlyphLang describes what a service does, not how.
 2. **Provider abstraction**: Services depend on capabilities, not specific libraries.

--- a/examples/feature-showcase/main.glyph
+++ b/examples/feature-showcase/main.glyph
@@ -328,32 +328,32 @@ type ChatMessage {
 # ============================================================================
 
 @ GET /api/factorial/:n {
-  $ n = parseInt(n)
+  $ limit = parseInt(n)
   $ result = 1
   $ i = 1
 
-  while i <= n {
-    $ result = result * i
-    $ i = i + 1
+  while i <= limit {
+    result = result * i
+    i = i + 1
   }
 
-  > {n: n, factorial: result}
+  > {n: limit, factorial: result}
 }
 
 @ GET /api/fibonacci/:count {
-  $ count = parseInt(count)
+  $ terms = parseInt(count)
   $ a = 0
   $ b = 1
   $ i = 0
 
-  while i < count {
+  while i < terms {
     $ temp = a + b
-    $ a = b
-    $ b = temp
-    $ i = i + 1
+    a = b
+    b = temp
+    i = i + 1
   }
 
-  > {count: count, result: a}
+  > {count: terms, result: a}
 }
 
 # Nested while loops

--- a/llms.txt
+++ b/llms.txt
@@ -31,6 +31,7 @@ binary — install from GitHub Releases (https://github.com/GlyphLang/GlyphLang/
 - Output plain GlyphLang source; one file is a complete service.
 - Symbols are glyphs only at the start of a line: `@` route, `:` type, `$` let, `>` return, `+` middleware, `%` inject provider, `<` expects input, `!` command/function, `*` cron, `~` event, `&` queue. Mid-expression they keep operator meaning.
 - Field modifiers: `T!` required, `T?` optional, `[T]` array, `A | B` union, `= value` default.
+- `$ name = expr` declares a binding; `name = expr` reassigns one. Redeclaring a name in the same scope is an error, and path/query parameters are already bound by the route.
 - Validate generated code with `glyph validate <file>` (add `--ai` for JSON errors), or use the `validate_glyph` tool from the MCP server started by `glyph mcp`.
 - The complete notation specification follows.
 
@@ -335,7 +336,48 @@ route GET /users/:id { use db: Database let user = db.users.Get(id) return user 
 
 Both are semantically identical and produce the same AST/IR.
 
-## 9. Control Flow
+## 9. Bindings and Reassignment
+
+`$` declares a new binding. Reassigning an existing one drops the sigil:
+
+```glyph
+$ total = 0        # declare
+total = total + 1  # reassign
+```
+
+Declaring the same name twice in one scope is an error - `cannot redeclare
+variable 'total' in the same scope` - so a running total, an accumulator, or a
+value refined by a later step uses the bare form after its first declaration:
+
+```glyph
+@ GET /api/cart/:id {
+  % db: Database
+
+  $ cart = db.carts.Get(id)
+  $ total = 0
+
+  for item in cart.items {
+    total = total + item.price
+  }
+
+  > {cart: cart, total: total}
+}
+```
+
+Path and query parameters are already bound by the route pattern, so they
+cannot be redeclared either. Assign to a different name instead:
+
+```glyph
+@ GET /api/factorial/:n {
+  $ limit = parseInt(n)   # not: $ n = parseInt(n)
+  ...
+}
+```
+
+Field assignment keeps the sigil, since it writes through an existing binding
+rather than introducing a name: `$ user.name = "Ada"`.
+
+## 10. Control Flow
 
 ```glyph
 # Conditionals
@@ -360,7 +402,7 @@ switch value {
 }
 ```
 
-## 10. Grammar (EBNF Summary)
+## 11. Grammar (EBNF Summary)
 
 ```ebnf
 program     = { item } ;
@@ -383,7 +425,8 @@ input_decl  = "<" IDENT ":" type ;
 validate    = "?" IDENT "(" [ args ] ")" ;
 guard       = "?" expr "::" INTEGER [ STRING ] ;
 statement   = assign | reassign | return | if | for | while | switch | expr_stmt ;
-assign      = "$" IDENT "=" expr ;
+assign      = "$" IDENT [ "." IDENT ] "=" expr ;
+reassign    = IDENT "=" expr ;
 return      = ">" expr [ "::" INTEGER ] ;
 
 type        = "int" | "float" | "str" | "bool" | "any"
@@ -395,7 +438,7 @@ type        = "int" | "float" | "str" | "bool" | "any"
 method      = "GET" | "POST" | "PUT" | "DELETE" | "PATCH" | "ws" | "sse" ;
 ```
 
-## 11. Design Principles
+## 12. Design Principles
 
 1. **Intent over implementation**: GlyphLang describes what a service does, not how.
 2. **Provider abstraction**: Services depend on capabilities, not specific libraries.

--- a/pkg/validate/compilation_test.go
+++ b/pkg/validate/compilation_test.go
@@ -1,0 +1,80 @@
+package validate
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestValidateRejectsRedeclaration covers the gap that let broken examples ship:
+// the compiler rejects a variable declared twice in one scope, but validation
+// stopped before that pass, so a file validated clean and then failed on the
+// first request to the route.
+func TestValidateRejectsRedeclaration(t *testing.T) {
+	src := `@ GET /api/count {
+  $ total = 0
+  $ total = 1
+  > {total: total}
+}`
+
+	result := NewValidator(src, "test.glyph").Validate()
+
+	if result.Valid {
+		t.Fatal("redeclaring a variable in the same scope must not validate")
+	}
+
+	var found *ValidationError
+	for _, e := range result.Errors {
+		if strings.Contains(e.Message, "redeclare variable") {
+			found = e
+			break
+		}
+	}
+	if found == nil {
+		t.Fatalf("expected a redeclaration error, got %+v", result.Errors)
+	}
+	// The hint carries the fix, since the notation spec left the reassignment
+	// form implicit and an agent reading only the error needs to know it.
+	if !strings.Contains(found.FixHint, "name = expr") {
+		t.Errorf("fix hint should show the reassignment form, got %q", found.FixHint)
+	}
+	if found.RelatedTo != "route GET /api/count" {
+		t.Errorf("error should name the route, got %q", found.RelatedTo)
+	}
+}
+
+// TestValidateAcceptsReassignment is the other half: the bare form is how a
+// running total is written, and it must stay valid.
+func TestValidateAcceptsReassignment(t *testing.T) {
+	src := `@ GET /api/count {
+  $ total = 0
+  total = total + 1
+  > {total: total}
+}`
+
+	result := NewValidator(src, "test.glyph").Validate()
+
+	if !result.Valid {
+		t.Fatalf("reassignment must validate, got errors: %+v", result.Errors)
+	}
+}
+
+// TestValidateRejectsPathParamShadowing covers the second form the compiler
+// rejects: a path parameter is already bound by the route pattern.
+func TestValidateRejectsPathParamShadowing(t *testing.T) {
+	src := `@ GET /api/factorial/:n {
+  $ n = parseInt(n)
+  > {n: n}
+}`
+
+	result := NewValidator(src, "test.glyph").Validate()
+
+	if result.Valid {
+		t.Fatal("shadowing a path parameter must not validate")
+	}
+	for _, e := range result.Errors {
+		if strings.Contains(e.Message, "redeclare path parameter") {
+			return
+		}
+	}
+	t.Fatalf("expected a path parameter error, got %+v", result.Errors)
+}

--- a/pkg/validate/validate.go
+++ b/pkg/validate/validate.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/glyphlang/glyph/pkg/ast"
+	"github.com/glyphlang/glyph/pkg/compiler"
 	"github.com/glyphlang/glyph/pkg/interpreter"
 	"github.com/glyphlang/glyph/pkg/parser"
 )
@@ -111,6 +112,9 @@ func (v *Validator) Validate() *ValidationResult {
 
 	// Phase 3: Semantic validation
 	v.validateSemantics(module, result)
+
+	// Phase 4: Compiler semantic pass
+	v.validateCompilation(module, result)
 
 	// Update stats
 	v.collectStats(module, result.Stats)
@@ -223,6 +227,53 @@ func (v *Validator) validateSemantics(module *ast.Module, result *ValidationResu
 
 	// Check for common issues
 	v.checkCommonIssues(module, result)
+}
+
+// validateCompilation runs the compiler's semantic pass over each route.
+//
+// Parsing and the checks above accept programs the compiler rejects - a
+// variable redeclared with $ being the common one - so without this a file
+// validates clean and then fails on the first request that hits the route.
+// Only semantic errors are reported: other compile failures mean the route
+// falls back to the interpreter, which is a codegen limit rather than a
+// defect in the program.
+func (v *Validator) validateCompilation(module *ast.Module, result *ValidationResult) {
+	for _, item := range module.Items {
+		route, ok := item.(*ast.Route)
+		if !ok {
+			continue
+		}
+
+		_, err := compiler.NewCompiler().CompileRoute(route)
+		if err == nil || !compiler.IsSemanticError(err) {
+			continue
+		}
+
+		result.Errors = append(result.Errors, &ValidationError{
+			Type:      ErrTypeDuplicate,
+			Message:   err.Error(),
+			Severity:  "error",
+			RelatedTo: fmt.Sprintf("route %s %s", route.Method, route.Path),
+			FixHint:   semanticFixHint(err.Error()),
+		})
+		result.Valid = false
+	}
+}
+
+// semanticFixHint maps a compiler semantic error to the action that resolves
+// it. Redeclaration is the case worth spelling out: $ declares a binding and
+// the bare form reassigns one, a distinction the notation spec left implicit.
+func semanticFixHint(msg string) string {
+	switch {
+	case strings.Contains(msg, "redeclare path parameter"):
+		return "the path parameter is already bound by the route pattern; assign to a differently named variable"
+	case strings.Contains(msg, "redeclare query parameter"):
+		return "the query parameter is already bound by the route's query declarations; assign to a differently named variable"
+	case strings.Contains(msg, "redeclare variable"):
+		return "use 'name = expr' to reassign an existing variable; '$ name = expr' declares a new one"
+	default:
+		return ""
+	}
 }
 
 // processImports processes import statements and adds imported types to the defined types map


### PR DESCRIPTION
Closes the gap that let nine broken examples pass as valid, and fixes the spec omission that caused them.

## 1. `glyph validate` now runs the compiler's semantic pass

Validation stopped after parsing and its own checks, so this validated clean and then 500'd on the first request:

```glyph
@ GET /api/count {
  $ total = 0
  $ total = 1     # cannot redeclare variable 'total' in the same scope
  > {total: total}
}
```

```
$ glyph validate redecl.glyph      # before
OK  redecl.glyph is valid

$ glyph validate redecl.glyph      # after
ERROR [duplicate_definition]: cannot redeclare variable 'a' in the same scope
  hint: use 'name = expr' to reassign an existing variable; '$ name = expr' declares a new one
```

Only *semantic* errors are reported. Other compile failures mean the route falls back to the interpreter - a codegen limit, not a defect in the program - and stay silent, matching the distinction `setupRoutes` already draws.

This also tightens the generation-accuracy eval, which checks glyph output with `glyph validate`. Until now a model could emit a redeclaration and score a pass on a program that cannot serve a request.

## 2. The spec caused the bug it was hiding

The grammar listed `reassign` as a statement form and never defined it:

```ebnf
statement   = assign | reassign | return | if | for | while | switch | expr_stmt ;
assign      = "$" IDENT "=" expr ;
```

So the only assignment syntax on show was `$ name = expr`, which is very likely why examples reached for it twice - and why a model reading the spec had no way to learn the reassignment form.

- New section 9 covers declaration versus reassignment, why path and query parameters cannot be redeclared, and field assignment keeping the sigil.
- The grammar defines `reassign = IDENT "=" expr ;` and widens `assign` to cover the field form.
- `llms.txt` carries the rule in its agent header, where a model sees it before the spec body. Header grew to 39 lines, so the `head -n` in the Makefile target moved with it.

## 3. It immediately caught two more real bugs

`examples/feature-showcase` shadowed its path parameters:

```glyph
@ GET /api/factorial/:n {
  $ n = parseInt(n)      # n is already bound by the route pattern
```

Both routes would have failed at runtime. Fixed and verified live: `factorial/5` returns 120, `fibonacci/10` returns 55.

## Verification

- Three new tests: redeclaration rejected with the fix hint and route name, reassignment still accepted, path-parameter shadowing rejected.
- All 44 example files validate under the stricter validator.
- `make llms.txt` is idempotent at the new header length - same sha256 across two runs, which is what CI's `git diff --exit-code` checks.
- Full `go test ./...` and `go vet ./...` pass.
