### PR TITLE
feat: wire the Redis, MongoDB and HTTP providers

### DIFF
--- a/cmd/glyph/handlers.go
+++ b/cmd/glyph/handlers.go
@@ -21,9 +21,12 @@ import (
 	"github.com/glyphlang/glyph/pkg/ast"
 	"github.com/glyphlang/glyph/pkg/compiler"
 	"github.com/glyphlang/glyph/pkg/database"
+	"github.com/glyphlang/glyph/pkg/httpclient"
 	"github.com/glyphlang/glyph/pkg/interpreter"
 	"github.com/glyphlang/glyph/pkg/llm"
+	"github.com/glyphlang/glyph/pkg/mongodb"
 	"github.com/glyphlang/glyph/pkg/parser"
+	"github.com/glyphlang/glyph/pkg/redis"
 	"github.com/glyphlang/glyph/pkg/server"
 	"github.com/glyphlang/glyph/pkg/vm"
 	"github.com/glyphlang/glyph/pkg/websocket"
@@ -61,6 +64,15 @@ func newConfiguredInterpreter() *interpreter.Interpreter {
 	} else if handler != nil {
 		interp.SetLLMHandler(handler)
 	}
+
+	// Redis and MongoDB follow the database pattern: an in-memory mock so a
+	// program runs with no infrastructure, replaced by a real client when the
+	// connection is configured.
+	interp.SetRedisHandler(newRedisHandler())
+	interp.SetMongoDBHandler(newMongoDBHandler())
+
+	// The HTTP provider needs no configuration.
+	interp.SetHTTPHandler(httpclient.NewHandler())
 
 	// Set up the parse function for module resolution
 	interp.GetModuleResolver().SetParseFunc(func(source string) (*ast.Module, error) {
@@ -663,6 +675,52 @@ func newLLMHandler() (*llm.Handler, error) {
 		return llm.NewHandlerWithBaseURL(provider, apiKey, baseURL)
 	}
 	return llm.NewHandler(provider, apiKey), nil
+}
+
+// newRedisHandler returns a real Redis client when GLYPH_REDIS_URL is set and
+// reachable, and the in-memory mock otherwise. Falling back rather than failing
+// keeps `glyph run` usable with no infrastructure, which is how the mock
+// database already behaves.
+func newRedisHandler() interface{} {
+	url := strings.TrimSpace(os.Getenv("GLYPH_REDIS_URL"))
+	if url == "" {
+		return redis.NewMockHandler()
+	}
+
+	handler, err := redis.NewHandlerFromURL(url)
+	if err != nil {
+		printWarning(fmt.Sprintf("GLYPH_REDIS_URL is set but unusable (%v): falling back to the in-memory mock", err))
+		return redis.NewMockHandler()
+	}
+	if _, err := handler.Ping(); err != nil {
+		printWarning(fmt.Sprintf("cannot reach Redis at %s (%v): falling back to the in-memory mock", url, err))
+		return redis.NewMockHandler()
+	}
+	printInfo("Connected to Redis at " + url)
+	return handler
+}
+
+// newMongoDBHandler mirrors newRedisHandler: GLYPH_MONGODB_URI selects a real
+// server, GLYPH_MONGODB_DATABASE names the database, and anything missing or
+// unreachable falls back to the in-memory mock.
+func newMongoDBHandler() interface{} {
+	uri := strings.TrimSpace(os.Getenv("GLYPH_MONGODB_URI"))
+	if uri == "" {
+		return mongodb.NewMockHandler()
+	}
+
+	dbName := strings.TrimSpace(os.Getenv("GLYPH_MONGODB_DATABASE"))
+	if dbName == "" {
+		dbName = "glyph"
+	}
+
+	handler, err := mongodb.NewHandlerFromURI(uri, dbName)
+	if err != nil {
+		printWarning(fmt.Sprintf("cannot reach MongoDB at %s (%v): falling back to the in-memory mock", uri, err))
+		return mongodb.NewMockHandler()
+	}
+	printInfo(fmt.Sprintf("Connected to MongoDB at %s (database %s)", uri, dbName))
+	return handler
 }
 
 // writeInternalError logs the full error server-side and sends a generic 500 to

--- a/pkg/httpclient/handler.go
+++ b/pkg/httpclient/handler.go
@@ -41,7 +41,7 @@ func NewHandlerWithTimeout(timeout time.Duration) *Handler {
 
 // Get performs an HTTP GET request.
 // Called from GlyphLang code: http.get("https://api.example.com/data")
-// or http.get("https://api.example.com/data", {headers: {"Authorization": "Bearer token"}})
+// or http.get({url: "https://api.example.com/data", headers: {"Authorization": "Bearer token"}})
 func (h *Handler) Get(args interface{}) (map[string]interface{}, error) {
 	reqURL, opts, err := parseRequestArgs(args)
 	if err != nil {
@@ -51,7 +51,8 @@ func (h *Handler) Get(args interface{}) (map[string]interface{}, error) {
 }
 
 // Post performs an HTTP POST request.
-// Called from GlyphLang code: http.post("https://api.example.com/submit", {body: payload, headers: {…}})
+// Called from GlyphLang code: http.post({url: "https://api.example.com/submit", body: payload, headers: {…}})
+// The url and options are one object: these methods take a single argument.
 func (h *Handler) Post(args interface{}) (map[string]interface{}, error) {
 	reqURL, opts, err := parseRequestArgs(args)
 	if err != nil {

--- a/pkg/interpreter/callmethod_arity_test.go
+++ b/pkg/interpreter/callmethod_arity_test.go
@@ -1,0 +1,51 @@
+package interpreter
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// arityTarget stands in for a provider handler: one method taking a single
+// argument, one variadic.
+type arityTarget struct{}
+
+func (arityTarget) Post(args interface{}) (map[string]interface{}, error) {
+	return map[string]interface{}{"ok": args}, nil
+}
+
+func (arityTarget) Del(keys ...interface{}) (int64, error) {
+	return int64(len(keys)), nil
+}
+
+// TestCallMethodRejectsWrongArity covers the crash path: reflect.Call panics on
+// an argument-count mismatch, which took down the whole request handler instead
+// of surfacing an error the route could report. Calling http.post with the
+// two-argument form its own docs used to show was enough to trigger it.
+func TestCallMethodRejectsWrongArity(t *testing.T) {
+	_, err := CallMethod(arityTarget{}, "Post", "https://example.com", map[string]interface{}{"body": 1})
+	require.Error(t, err, "a two-argument call to a one-argument method must error, not panic")
+	assert.Contains(t, err.Error(), "expects 1 argument(s), got 2")
+
+	_, err = CallMethod(arityTarget{}, "Post")
+	require.Error(t, err, "a zero-argument call to a one-argument method must error")
+}
+
+// TestCallMethodAcceptsCorrectArity keeps the guard from over-rejecting, and
+// covers variadic methods, which Redis uses heavily (Del, Exists, HSet).
+func TestCallMethodAcceptsCorrectArity(t *testing.T) {
+	result, err := CallMethod(arityTarget{}, "Post", map[string]interface{}{"url": "https://example.com"})
+	require.NoError(t, err)
+	assert.NotNil(t, result)
+
+	for _, args := range [][]interface{}{
+		{},
+		{"one"},
+		{"one", "two", "three"},
+	} {
+		count, err := CallMethod(arityTarget{}, "Del", args...)
+		require.NoError(t, err, "variadic call with %d args", len(args))
+		assert.Equal(t, int64(len(args)), count)
+	}
+}

--- a/pkg/interpreter/database.go
+++ b/pkg/interpreter/database.go
@@ -120,6 +120,11 @@ var allowedMethods = map[string]bool{
 	"Aggregate":      true,
 	"CreateIndex":    true,
 	"DropIndex":      true,
+	// HTTP methods. Get and Delete are already listed above for the database
+	// providers; Post, Put and Patch are unique to this one.
+	"Post":  true,
+	"Put":   true,
+	"Patch": true,
 	// LLM methods
 	"Complete":   true,
 	"Chat":       true,
@@ -155,6 +160,20 @@ func CallMethod(obj interface{}, methodName string, args ...interface{}) (interf
 	method := objValue.MethodByName(methodName)
 	if !method.IsValid() {
 		return nil, fmt.Errorf("method %s not found on type %s", methodName, objType)
+	}
+
+	// Reject a wrong argument count before calling. reflect.Call panics on a
+	// mismatch, and a panic in a provider call takes down the request handler
+	// instead of returning an error the route can report.
+	methodType := method.Type()
+	if methodType.IsVariadic() {
+		if len(args) < methodType.NumIn()-1 {
+			return nil, fmt.Errorf("method %s expects at least %d argument(s), got %d",
+				methodName, methodType.NumIn()-1, len(args))
+		}
+	} else if len(args) != methodType.NumIn() {
+		return nil, fmt.Errorf("method %s expects %d argument(s), got %d",
+			methodName, methodType.NumIn(), len(args))
 	}
 
 	// Prepare arguments

--- a/pkg/interpreter/typechecker.go
+++ b/pkg/interpreter/typechecker.go
@@ -110,6 +110,13 @@ func (tc *TypeChecker) CheckType(value interface{}, expectedType Type) error {
 		switch et.Name {
 		case "Database", "Redis", "MongoDB", "LLM":
 			return nil
+		case "any", "object":
+			// `any` accepts every value, null included. Without this the
+			// check below rejects null (which has no runtime type) and every
+			// concrete type (none of which equal NamedType "any"), so a field
+			// declared `any` could hold nothing at all. The parser already
+			// skips literals of these types; this is the runtime half.
+			return nil
 		}
 	}
 


### PR DESCRIPTION
Stacked on #307 (which is green) - review that first; GitHub retargets this to main when it merges. Note that CI does not run on PRs targeting a non-main branch, so the checks here will stay empty until then.

Finishes the provider work started in #306. Only Database had a runtime binding, so every other injection compiled and then failed on the first request:

```
[GET] /api/users/:id [ERROR] undefined object: redis
```

## Wiring

- **Redis and MongoDB** follow the database pattern: an in-memory mock so a program runs with no infrastructure, replaced by a real client when `GLYPH_REDIS_URL` or `GLYPH_MONGODB_URI` is set (`GLYPH_MONGODB_DATABASE` names the database, default `glyph`). An unreachable or malformed connection warns and falls back rather than refusing to start:

```
[WARNING] cannot reach Redis at redis://127.0.0.1:6399 (dial tcp ... refused): falling back to the in-memory mock
[SUCCESS] Server listening on http://localhost:8078 (interpreted mode)
```

- **HTTP** needs no configuration and is always available. Its `Post`, `Put` and `Patch` were missing from the method whitelist so they were rejected as "not allowed" - `Get` and `Delete` were already listed for the database providers.

## Two bugs found while verifying

**`any` rejected every value.** The runtime check compared a concrete type against `NamedType{"any"}` and failed, and null has no runtime type at all, so a field declared `any` could hold nothing:

```
return type mismatch: field data: cannot determine type of value: <nil>
return type mismatch: field data: type mismatch: expected any, got int
```

It now short-circuits alongside the provider types, matching what the parser already does for literals of `any`/`object`.

**A wrong argument count panicked the request handler.** `reflect.Call` panics on a mismatch, and `http.post`'s own doc comment showed a two-argument form its single-argument method cannot accept - so following the documentation crashed the handler:

```
http: panic serving [::1]:51219: reflect: Call with too many input arguments
```

`CallMethod` now checks arity (variadic included) and returns an error the route reports as a 500. The comments show the real single-object form.

## Verification

| check | result |
|---|---|
| `redis-cache` on the mock: GET, cache hit, incr, delete | all 200, zero errors logged |
| `redis-cache` with unreachable `GLYPH_REDIS_URL` | warns, falls back, server serves |
| malformed `GLYPH_REDIS_URL` | warns with the parse error, falls back |
| HTTP provider against a local stub | `{"status":200}` |
| wrong-arity provider call | `method Post expects 1 argument(s), got 2`, no panic |

New tests cover the arity guard for both fixed and variadic methods. Full `go test ./...` and `go vet ./...` pass; all 44 examples validate.

## Not verified, and one still broken

- **The connected Redis/MongoDB paths are unverified.** Docker's CLI is installed here but the daemon is not running, so I could only exercise the mock and the failure paths. The client construction and ping are real code, but nobody has watched them talk to a live server.
- **`examples/mongodb-demo` still fails.** `mongo.Collection("users").InsertOne(input)` returns `undefined function: InsertOne`. The mock collection implements every method and they are all whitelisted, so this is a chained-call dispatch gap in the interpreter, not a wiring or permission problem. Separate bug, worth its own issue.
