### PR TITLE
test: run the examples in CI, and fix what that exposed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,26 @@ jobs:
         run: |
           go test -v -short -coverprofile=coverage.out -covermode=atomic $(go list ./... | grep -v /websocket)
 
+      - name: Validate every example
+        # Examples are the showcase surface and nothing checked them, so broken
+        # ones shipped. validate runs the compiler's semantic pass, which is
+        # what catches redeclared variables and shadowed path parameters.
+        run: |
+          go build -o glyph-ci ./cmd/glyph
+          status=0
+          while IFS= read -r file; do
+            ./glyph-ci validate "$file" --quiet || status=1
+          done < <(find examples -name '*.glyph')
+          rm -f glyph-ci
+          exit $status
+        shell: bash
+
+      - name: Smoke-test examples over HTTP
+        # Boots each example and requests its parameter-free GET routes,
+        # failing on any 5xx. Excluded from -short above because it spawns
+        # servers, so it needs its own step.
+        run: go test ./tests/ -run TestExamplesServeWithoutServerErrors -count=1
+
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v7
         with:

--- a/pkg/interpreter/database.go
+++ b/pkg/interpreter/database.go
@@ -3,6 +3,7 @@ package interpreter
 import (
 	"fmt"
 	"reflect"
+	"strings"
 )
 
 // providerMethods provides per-provider method whitelists for scoped access control.
@@ -144,11 +145,6 @@ var allowedMethods = map[string]bool{
 // CallMethod calls a method on an object using reflection
 // Only methods in the allowedMethods whitelist can be called for security
 func CallMethod(obj interface{}, methodName string, args ...interface{}) (interface{}, error) {
-	// Check if the method is in the whitelist
-	if !allowedMethods[methodName] {
-		return nil, fmt.Errorf("method %s is not allowed", methodName)
-	}
-
 	// Get the value and type of the object
 	objValue := reflect.ValueOf(obj)
 	if !objValue.IsValid() {
@@ -156,8 +152,14 @@ func CallMethod(obj interface{}, methodName string, args ...interface{}) (interf
 	}
 	objType := objValue.Type()
 
-	// Find the method
-	method := objValue.MethodByName(methodName)
+	// Whitelist first: a name that is not listed is rejected before any lookup
+	// happens, so nothing about the object is reachable through a blocked name.
+	canonical, allowed := canonicalMethodName(methodName)
+	if !allowed {
+		return nil, fmt.Errorf("method %s is not allowed", methodName)
+	}
+
+	method := objValue.MethodByName(canonical)
 	if !method.IsValid() {
 		return nil, fmt.Errorf("method %s not found on type %s", methodName, objType)
 	}
@@ -207,14 +209,38 @@ func CallMethod(obj interface{}, methodName string, args ...interface{}) (interf
 	return results[0].Interface(), nil
 }
 
-// HasMethod checks if an object has a method
+// canonicalMethodName maps a called name to its whitelisted Go spelling.
+//
+// GlyphLang calls provider methods in lowercase (redis.lrange, redis.hgetall)
+// and only the first letter is capitalized before lookup, producing "Lrange"
+// and "Hgetall" - names no Go method has. Matching the whitelist without regard
+// to case makes every multi-word provider method reachable from the notation.
+// The match is against the whitelist itself, so an unlisted name resolves to
+// nothing no matter how it is spelled.
+func canonicalMethodName(methodName string) (string, bool) {
+	if allowedMethods[methodName] {
+		return methodName, true
+	}
+	for candidate := range allowedMethods {
+		if strings.EqualFold(candidate, methodName) {
+			return candidate, true
+		}
+	}
+	return "", false
+}
+
+// HasMethod checks if an object has a callable method under the given name,
+// using the same canonical spelling CallMethod will use.
 func HasMethod(obj interface{}, methodName string) bool {
 	objValue := reflect.ValueOf(obj)
 	if !objValue.IsValid() {
 		return false
 	}
-	method := objValue.MethodByName(methodName)
-	return method.IsValid()
+	if objValue.MethodByName(methodName).IsValid() {
+		return true
+	}
+	canonical, allowed := canonicalMethodName(methodName)
+	return allowed && objValue.MethodByName(canonical).IsValid()
 }
 
 // GetMethodNames returns all method names of an object

--- a/pkg/interpreter/typechecker.go
+++ b/pkg/interpreter/typechecker.go
@@ -120,6 +120,15 @@ func (tc *TypeChecker) CheckType(value interface{}, expectedType Type) error {
 		}
 	}
 
+	// A null value has no runtime type to compare. Whether null is acceptable
+	// is a question of requiredness, which the caller enforces separately with
+	// "missing required field" - only `!` marks a field required. Rejecting
+	// null here made every not-found response ("user: null") fail its own
+	// return type.
+	if value == nil {
+		return nil
+	}
+
 	actualType := GetRuntimeType(value)
 	if actualType == nil {
 		return fmt.Errorf("cannot determine type of value: %T", value)
@@ -161,6 +170,25 @@ func (tc *TypeChecker) TypesCompatible(actual, expected Type) bool {
 	// Nil types are always compatible
 	if actual == nil || expected == nil {
 		return true
+	}
+
+	// A runtime array carries no element type (GetRuntimeType cannot infer one,
+	// and an empty array has none to infer), so it is compatible with any list
+	// type. Without this an empty result set fails `List<Product>` and every
+	// listing route 500s until the first record exists.
+	if actualArray, ok := actual.(ArrayType); ok && actualArray.ElementType == nil {
+		switch exp := expected.(type) {
+		case ArrayType:
+			return true
+		case GenericType:
+			if named, ok := exp.BaseType.(NamedType); ok && named.Name == "List" {
+				return true
+			}
+		case NamedType:
+			if exp.Name == "List" || exp.Name == "any" || exp.Name == "object" {
+				return true
+			}
+		}
 	}
 
 	// Check for exact type match

--- a/tests/examples_runtime_test.go
+++ b/tests/examples_runtime_test.go
@@ -1,0 +1,193 @@
+package tests
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+)
+
+// Examples are the project's showcase surface, but nothing executed them: only
+// two were exercised by tests, and CI never ran any. That is how a route that
+// answered "Internal server error" on every request, and a provider that was
+// never wired at all, both shipped while `glyph validate` reported success.
+//
+// This boots each example with the real binary and requests its parameter-free
+// GET routes. It asserts only that nothing returns 5xx - a 401 from an auth
+// directive or a 404 from an empty mock database is a working route.
+
+// knownBroken lists examples whose routes still fail, with the reason each one
+// fails. They are skipped so this test can guard the 14 that work; an entry
+// here is coverage we do not have yet, not a route that is fine.
+//
+// Three themes, none of them a wiring problem: examples calling functions that
+// do not exist, examples reading a query parameter that was not supplied, and
+// examples returning objects missing a required field.
+var knownBroken = map[string]string{
+	"mongodb-demo":      "mongo.Collection(x).InsertOne(y): chained provider calls are not dispatched",
+	"auth-demo":         "GET /api/auth/me returns an object missing the required field id",
+	"blog-api":          "calls paginate(), which is not a builtin",
+	"blog-api-complete": "calls timestamp(), which is not a builtin",
+	"e-commerce-api":    "calls timestamp(), which is not a builtin",
+	"macros-demo":       "calls db.insert(), which the database provider does not expose",
+	"cart-api":          "calls filter() with 3 arguments; it takes 2 (array, function)",
+	"feature-showcase":  "calls filter() with 3 arguments; it takes 2 (array, function)",
+	"database-demo":     "calls length() on a table handler rather than a collection",
+	"collections-demo":  "reads query.category when the parameter is absent, which errors instead of yielding null",
+	"defaults-demo":     "reads query.page when the parameter is absent; declared defaults are not applied",
+	"validation-demo":   "reads query.q when the parameter is absent",
+	"query-params-demo": "field not found: category, when the query parameter is absent",
+}
+
+var paramFreeGetRoute = regexp.MustCompile(`(?m)^@\s+GET\s+(/[^\s:{]*)\s*(->[^{]*)?\{`)
+
+func TestExamplesServeWithoutServerErrors(t *testing.T) {
+	if testing.Short() {
+		t.Skip("boots a server per example; skipped in -short")
+	}
+
+	binary := buildGlyphBinary(t)
+
+	files, err := filepath.Glob(filepath.Join("..", "examples", "*", "main.glyph"))
+	if err != nil {
+		t.Fatalf("globbing examples: %v", err)
+	}
+	if len(files) == 0 {
+		t.Fatal("no examples found - the glob or layout changed")
+	}
+
+	for _, file := range files {
+		name := filepath.Base(filepath.Dir(file))
+
+		if reason, skip := knownBroken[name]; skip {
+			t.Run(name, func(t *testing.T) { t.Skipf("known broken: %s", reason) })
+			continue
+		}
+
+		routes := paramFreeGetRoutes(t, file)
+		if len(routes) == 0 {
+			continue // nothing this test can drive without inventing inputs
+		}
+
+		t.Run(name, func(t *testing.T) {
+			port := freePort(t)
+			stop, logs := startExample(t, binary, file, port)
+			defer stop()
+
+			for _, route := range routes {
+				url := fmt.Sprintf("http://127.0.0.1:%d%s", port, route)
+				resp, err := http.Get(url)
+				if err != nil {
+					t.Errorf("GET %s: %v\nserver log:\n%s", route, err, logs())
+					continue
+				}
+				resp.Body.Close()
+
+				if resp.StatusCode >= 500 {
+					t.Errorf("GET %s returned %d, want < 500\nserver log:\n%s",
+						route, resp.StatusCode, logs())
+				}
+			}
+		})
+	}
+}
+
+// paramFreeGetRoutes returns GET paths that take no path parameter, so they can
+// be requested without inventing an id that exists.
+func paramFreeGetRoutes(t *testing.T, file string) []string {
+	t.Helper()
+
+	source, err := os.ReadFile(file)
+	if err != nil {
+		t.Fatalf("reading %s: %v", file, err)
+	}
+
+	var routes []string
+	for _, match := range paramFreeGetRoute.FindAllStringSubmatch(string(source), -1) {
+		path := strings.TrimSpace(match[1])
+		if path != "" && !strings.Contains(path, ":") {
+			routes = append(routes, path)
+		}
+	}
+	return routes
+}
+
+func buildGlyphBinary(t *testing.T) string {
+	t.Helper()
+
+	binary := filepath.Join(t.TempDir(), "glyph")
+	if isWindows() {
+		binary += ".exe"
+	}
+
+	build := exec.Command("go", "build", "-o", binary, "./cmd/glyph")
+	build.Dir = ".."
+	if out, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("building glyph: %v\n%s", err, out)
+	}
+	return binary
+}
+
+// startExample runs one example and waits for it to accept connections.
+// Returns a stop function and an accessor for the server's output, which is
+// what explains a failure.
+func startExample(t *testing.T, binary, file string, port int) (func(), func() string) {
+	t.Helper()
+
+	var output strings.Builder
+	// No cmd.Dir: file is already relative to this package's directory, and
+	// examples resolve their module imports from their own path.
+	cmd := exec.Command(binary, "run", file, "--port", fmt.Sprint(port))
+	cmd.Stdout = &output
+	cmd.Stderr = &output
+
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("starting %s: %v", file, err)
+	}
+
+	stop := func() {
+		if cmd.Process != nil {
+			_ = cmd.Process.Kill()
+			_, _ = cmd.Process.Wait()
+		}
+	}
+	logs := func() string { return output.String() }
+
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		conn, err := net.DialTimeout("tcp", fmt.Sprintf("127.0.0.1:%d", port), 200*time.Millisecond)
+		if err == nil {
+			conn.Close()
+			return stop, logs
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	stop()
+	t.Fatalf("%s did not listen on port %d within 10s\nserver log:\n%s", file, port, output.String())
+	return stop, logs
+}
+
+// freePort asks the OS for an unused port and releases it. The server binds it
+// moments later; a collision would need another process to take the same port
+// in that window.
+func freePort(t *testing.T) int {
+	t.Helper()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("reserving a port: %v", err)
+	}
+	defer listener.Close()
+	return listener.Addr().(*net.TCPAddr).Port
+}
+
+func isWindows() bool {
+	return os.PathSeparator == '\\'
+}


### PR DESCRIPTION
Stacked on #308 -> #307. Review order is #307, #308, then this. CI does not run on PRs targeting a non-main branch, so checks stay empty here until the stack merges.

Nothing executed the examples. Two were exercised by tests, CI ran none. That is how a route answering 500 on every request, and a provider that was never wired, both shipped while `glyph validate` reported success.

## Two layers

**Validate every example** (CI step). Since #307 this runs the compiler's semantic pass, so it catches redeclared variables and shadowed path parameters. Verified in both directions: passes on the current tree, and exits 1 when a deliberately broken example is dropped in.

**Boot each example and request its parameter-free GET routes** (`tests/examples_runtime_test.go`), failing on any 5xx. It asserts only that - a 401 from an auth directive or a 404 from an empty mock database is a working route. Routes with `:params` are skipped rather than fed invented ids. Runs against the real binary, so it covers the CLI wiring where the missing providers actually lived. Excluded from `-short` because it spawns servers, so CI runs it as its own step. Whole suite takes about 3 seconds.

## What it found on the first run

24 failing routes. Three runtime bugs accounted for ten:

**Null failed every type check.** A null value has no runtime type, so the checker rejected it outright:

```
return type mismatch: field user: cannot determine type of value: <nil>
```

Every not-found response that returns `user: null` failed its own return type. Requiredness is enforced separately by the "missing required field" check, and only `!` marks a field required.

**An empty array satisfied no list type.** Runtime arrays carry no element type, so an empty result set failed `List<Product>` and every listing route 500'd until the first record existed.

**Multi-word provider methods were unreachable.** Calls are lowercase (`redis.lrange`) and only the first letter is capitalized before lookup, producing `Lrange` - a name no Go method has. So `LRange`, `HGetAll`, `LPush`, `SMembers` and friends could not be called at all. The whitelist is now matched without regard to case, and it is still consulted *before* any lookup, so a blocked name still reveals nothing about the object. The existing security test for blocked methods caught my first attempt at this, which had reordered those two steps.

## The remaining twelve

Skipped with the reason each one fails, so the fourteen that work are guarded now rather than after a cleanup:

| theme | examples |
|---|---|
| calls a function that does not exist (`paginate`, `timestamp`, `db.insert`) | blog-api, blog-api-complete, e-commerce-api, macros-demo |
| reads a query parameter that was not supplied | collections-demo, defaults-demo, validation-demo, query-params-demo |
| `filter()` called with 3 arguments; it takes 2 | cart-api, feature-showcase |
| returns an object missing a required field | auth-demo |
| other | database-demo (`length()` on a table handler), mongodb-demo (chained provider calls) |

None is a wiring problem. The query-parameter group looks like a genuine runtime bug - reading an absent parameter errors instead of yielding null, and `defaults-demo` suggests declared defaults are not applied in compiled mode - but I stopped at diagnosis rather than widening this further.

## Verification

- 14 examples pass, 12 skip with reasons, suite is green in ~3s.
- CI validate step simulated locally, including the negative control.
- `gofmt`, `go vet ./...`, full `go test ./...` all clean.
