### PR TITLE
fix: enforce the auth and ratelimit directives

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Java:      @GetMapping("/users/{id}")...  (28 tokens)
 ### Infrastructure
 - **HTTP Server** - routes, middleware, WebSocket support
 - **Database** - PostgreSQL with pooling, transactions, migrations
-- **Security** - JWT auth, rate limiting, CORS, SQL injection prevention
+- **Security** - token auth, rate limiting, CORS, SQL injection prevention. `+ auth(...)` and `+ ratelimit(...)` are enforced by the server; credentials come from `GLYPH_JWT_SECRET` or `GLYPH_API_KEYS`, and a route declaring auth with neither set denies every request
 - **Observability** - logging, Prometheus metrics, OpenTelemetry tracing
 
 ### Code Generation

--- a/cmd/glyph/handlers.go
+++ b/cmd/glyph/handlers.go
@@ -93,9 +93,10 @@ func registerRoute(router *server.Router, route *ast.Route, interp *interpreter.
 	handler := createRouteHandler(route, interp)
 
 	serverRoute := &server.Route{
-		Method:  convertHTTPMethod(route.Method),
-		Path:    route.Path,
-		Handler: handler,
+		Method:      convertHTTPMethod(route.Method),
+		Path:        route.Path,
+		Handler:     handler,
+		Middlewares: routeMiddlewares(route),
 	}
 
 	return router.RegisterRoute(serverRoute)
@@ -106,9 +107,10 @@ func registerCompiledRoute(router *server.Router, route *ast.Route, bytecode []b
 	handler := createCompiledRouteHandler(route, bytecode, wsHub)
 
 	serverRoute := &server.Route{
-		Method:  convertHTTPMethod(route.Method),
-		Path:    route.Path,
-		Handler: handler,
+		Method:      convertHTTPMethod(route.Method),
+		Path:        route.Path,
+		Handler:     handler,
+		Middlewares: routeMiddlewares(route),
 	}
 
 	return router.RegisterRoute(serverRoute)
@@ -440,8 +442,16 @@ func createHandler(router *server.Router) http.HandlerFunc {
 			StatusCode:     http.StatusOK,
 		}
 
+		// Apply the route's middlewares, outermost first. This dispatcher used
+		// to call Handler directly, which silently discarded every declared
+		// auth and rate limit.
+		handler := route.Handler
+		for i := len(route.Middlewares) - 1; i >= 0; i-- {
+			handler = route.Middlewares[i](handler)
+		}
+
 		// Execute handler
-		if err := route.Handler(ctx); err != nil {
+		if err := handler(ctx); err != nil {
 			printError(fmt.Errorf("handler error for %s %s: %w", r.Method, r.URL.Path, err))
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusInternalServerError)

--- a/cmd/glyph/route_middleware.go
+++ b/cmd/glyph/route_middleware.go
@@ -1,0 +1,178 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/glyphlang/glyph/pkg/ast"
+	"github.com/glyphlang/glyph/pkg/server"
+)
+
+// Routes declare `+ auth(jwt)` and `+ ratelimit(100/min)`, the parser records
+// them on ast.Route, and pkg/server already applies Route.Middlewares - but
+// nothing ever built the middlewares, so both directives were silently inert
+// and a route declaring auth served anyone.
+//
+// Credentials come from the environment, like the provider configuration, so a
+// .glyph file carries none.
+const (
+	envJWTSecret = "GLYPH_JWT_SECRET"
+	envAPIKeys   = "GLYPH_API_KEYS"
+)
+
+// authEnvHint names the variable a given auth type needs.
+func authEnvHint(authType string) string {
+	if strings.EqualFold(authType, "apikey") {
+		return envAPIKeys + " (comma-separated keys)"
+	}
+	return envJWTSecret
+}
+
+// routeMiddlewares builds the middleware chain for one route from its declared
+// directives. Order matters: rate limiting runs first so an unauthenticated
+// flood is cheap to reject.
+func routeMiddlewares(route *ast.Route) []server.Middleware {
+	var middlewares []server.Middleware
+
+	if limit := rateLimitMiddleware(route.RateLimit); limit != nil {
+		middlewares = append(middlewares, limit)
+	}
+	if auth := authMiddleware(route.Auth); auth != nil {
+		middlewares = append(middlewares, auth)
+	}
+	return middlewares
+}
+
+// rateLimitMiddleware converts a declared limit into a per-minute budget.
+func rateLimitMiddleware(limit *ast.RateLimit) server.Middleware {
+	if limit == nil || limit.Requests == 0 {
+		return nil
+	}
+
+	perMinute := int(limit.Requests)
+	switch strings.ToLower(strings.TrimSpace(limit.Window)) {
+	case "sec", "second", "s":
+		perMinute = int(limit.Requests) * 60
+	case "hour", "hr", "h":
+		// Round up so a declared budget is never reduced to zero.
+		perMinute = (int(limit.Requests) + 59) / 60
+	case "day", "d":
+		perMinute = (int(limit.Requests) + 1439) / 1440
+	}
+	if perMinute < 1 {
+		perMinute = 1
+	}
+
+	return server.RateLimitMiddleware(server.RateLimiterConfig{
+		RequestsPerMinute: perMinute,
+		BurstSize:         perMinute,
+	})
+}
+
+// authMiddleware builds credential checking for a declared auth directive.
+//
+// It fails closed: when a route declares auth and no credential source is
+// configured, every request is rejected rather than served. An unconfigured
+// deployment that silently served protected routes is the bug this fixes, so
+// the safe direction is to deny and warn loudly at startup.
+func authMiddleware(auth *ast.AuthConfig) server.Middleware {
+	if auth == nil {
+		return nil
+	}
+
+	if strings.EqualFold(auth.AuthType, "apikey") {
+		keys := parseAPIKeys(os.Getenv(envAPIKeys))
+		if len(keys) == 0 {
+			return denyAllMiddleware("apikey")
+		}
+		return apiKeyMiddleware(keys)
+	}
+
+	// Everything else is treated as bearer-token auth (jwt is the only other
+	// form the notation defines today).
+	secret := strings.TrimSpace(os.Getenv(envJWTSecret))
+	if secret == "" {
+		return denyAllMiddleware(auth.AuthType)
+	}
+	return server.BasicAuthMiddleware(map[string]bool{secret: true})
+}
+
+// parseAPIKeys splits the configured key list, ignoring blanks.
+func parseAPIKeys(raw string) map[string]bool {
+	keys := make(map[string]bool)
+	for _, key := range strings.Split(raw, ",") {
+		if trimmed := strings.TrimSpace(key); trimmed != "" {
+			keys[trimmed] = true
+		}
+	}
+	return keys
+}
+
+// apiKeyMiddleware accepts a key from X-API-Key or a Bearer authorization
+// header, so a caller can use whichever its client library supports.
+func apiKeyMiddleware(validKeys map[string]bool) server.Middleware {
+	return func(next server.RouteHandler) server.RouteHandler {
+		return func(ctx *server.Context) error {
+			key := strings.TrimSpace(ctx.Request.Header.Get("X-API-Key"))
+			if key == "" {
+				const bearer = "Bearer "
+				authHeader := ctx.Request.Header.Get("Authorization")
+				if strings.HasPrefix(authHeader, bearer) {
+					key = strings.TrimSpace(strings.TrimPrefix(authHeader, bearer))
+				}
+			}
+
+			if key == "" {
+				return server.SendError(ctx, 401, "unauthorized: missing API key")
+			}
+			if !validKeys[key] {
+				return server.SendError(ctx, 401, "unauthorized: invalid API key")
+			}
+			return next(ctx)
+		}
+	}
+}
+
+// denyAllMiddleware rejects every request to a route whose auth is declared but
+// unconfigured. The response says nothing about the server's configuration; the
+// startup warning tells the operator what to set.
+func denyAllMiddleware(authType string) server.Middleware {
+	return func(next server.RouteHandler) server.RouteHandler {
+		return func(ctx *server.Context) error {
+			return server.SendError(ctx, 401, "unauthorized")
+		}
+	}
+}
+
+// warnUnconfiguredAuth reports, once per auth type, that routes declare auth
+// with nothing configured to check it - the case where every request to those
+// routes is denied.
+func warnUnconfiguredAuth(module *ast.Module) {
+	warned := make(map[string]bool)
+
+	for _, item := range module.Items {
+		route, ok := item.(*ast.Route)
+		if !ok || route.Auth == nil {
+			continue
+		}
+
+		authType := strings.ToLower(route.Auth.AuthType)
+		if warned[authType] {
+			continue
+		}
+
+		configured := os.Getenv(envJWTSecret) != ""
+		if strings.EqualFold(authType, "apikey") {
+			configured = len(parseAPIKeys(os.Getenv(envAPIKeys))) > 0
+		}
+		if configured {
+			continue
+		}
+
+		warned[authType] = true
+		printWarning(fmt.Sprintf(
+			"routes declare auth(%s) but %s is not set: those routes will reject every request",
+			authType, authEnvHint(authType)))
+	}
+}

--- a/cmd/glyph/route_middleware_test.go
+++ b/cmd/glyph/route_middleware_test.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/glyphlang/glyph/pkg/ast"
+	"github.com/glyphlang/glyph/pkg/server"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A route declaring auth or a rate limit served every request: the directives
+// were parsed onto ast.Route and never turned into middleware. These tests fix
+// the behaviour in place so the wiring cannot be dropped again.
+
+// guard builds a route's middleware chain once and returns a function that
+// issues one request through it. Building the chain per request would hand
+// every call a fresh rate-limit bucket and no limit would ever be reached.
+func guard(t *testing.T, route *ast.Route) func(decorate func(*http.Request)) int {
+	t.Helper()
+
+	handler := server.RouteHandler(func(ctx *server.Context) error {
+		return server.SendJSON(ctx, http.StatusOK, map[string]interface{}{"ok": true})
+	})
+	middlewares := routeMiddlewares(route)
+	for i := len(middlewares) - 1; i >= 0; i-- {
+		handler = middlewares[i](handler)
+	}
+
+	return func(decorate func(*http.Request)) int {
+		req := httptest.NewRequest("GET", "/guarded", nil)
+		if decorate != nil {
+			decorate(req)
+		}
+		// A fixed remote address: the identity these middlewares key on must
+		// not vary per request, or no limit is ever reached.
+		req.RemoteAddr = "203.0.113.7:44321"
+
+		rec := httptest.NewRecorder()
+		ctx := &server.Context{
+			Request:        req,
+			ResponseWriter: rec,
+			PathParams:     map[string]string{},
+			StatusCode:     http.StatusOK,
+		}
+
+		require.NoError(t, handler(ctx))
+		return rec.Code
+	}
+}
+
+func TestAPIKeyAuthEnforced(t *testing.T) {
+	t.Setenv(envAPIKeys, "key-one, key-two")
+	request := guard(t, &ast.Route{Auth: &ast.AuthConfig{AuthType: "apikey", Required: true}})
+
+	assert.Equal(t, 401, request(nil), "no key must be rejected")
+	assert.Equal(t, 401, request(func(r *http.Request) {
+		r.Header.Set("X-API-Key", "wrong")
+	}), "an unknown key must be rejected")
+	assert.Equal(t, 200, request(func(r *http.Request) {
+		r.Header.Set("X-API-Key", "key-two")
+	}), "a configured key must pass")
+	assert.Equal(t, 200, request(func(r *http.Request) {
+		r.Header.Set("Authorization", "Bearer key-one")
+	}), "a configured key must pass as a bearer token too")
+}
+
+// TestUnconfiguredAuthFailsClosed is the property that matters most: a route
+// that declares auth with nothing configured to check it must deny, not serve.
+func TestUnconfiguredAuthFailsClosed(t *testing.T) {
+	t.Setenv(envAPIKeys, "")
+	t.Setenv(envJWTSecret, "")
+
+	for _, authType := range []string{"apikey", "jwt"} {
+		request := guard(t, &ast.Route{Auth: &ast.AuthConfig{AuthType: authType, Required: true}})
+		assert.Equal(t, 401, request(func(r *http.Request) {
+			r.Header.Set("X-API-Key", "anything")
+			r.Header.Set("Authorization", "Bearer anything")
+		}), "auth(%s) with no credential configured must deny", authType)
+	}
+}
+
+func TestRateLimitEnforced(t *testing.T) {
+	request := guard(t, &ast.Route{RateLimit: &ast.RateLimit{Requests: 2, Window: "min"}})
+
+	assert.Equal(t, 200, request(nil), "first request within budget")
+	assert.Equal(t, 200, request(nil), "second request within budget")
+	assert.Equal(t, 429, request(nil), "third request exceeds 2/min")
+}
+
+// TestRateLimitWindowConversion checks the per-minute budget each declared
+// window produces, including the rounding that keeps an hourly budget from
+// collapsing to zero requests per minute.
+func TestRateLimitWindowConversion(t *testing.T) {
+	for _, tc := range []struct {
+		window   string
+		requests uint32
+		allowed  int
+	}{
+		{"min", 3, 3},
+		{"sec", 1, 60},
+		{"hour", 120, 2},
+		{"hour", 30, 1}, // rounds up rather than down to zero
+	} {
+		request := guard(t, &ast.Route{RateLimit: &ast.RateLimit{Requests: tc.requests, Window: tc.window}})
+
+		for i := 0; i < tc.allowed; i++ {
+			assert.Equal(t, 200, request(nil),
+				"%d/%s: request %d should be within the budget of %d",
+				tc.requests, tc.window, i+1, tc.allowed)
+		}
+		assert.Equal(t, 429, request(nil),
+			"%d/%s: request %d should exceed the budget of %d",
+			tc.requests, tc.window, tc.allowed+1, tc.allowed)
+	}
+}
+
+func TestNoDirectivesMeansNoMiddleware(t *testing.T) {
+	assert.Empty(t, routeMiddlewares(&ast.Route{}),
+		"a route without directives should not be wrapped")
+}

--- a/cmd/glyph/routes.go
+++ b/cmd/glyph/routes.go
@@ -61,6 +61,10 @@ func setupRoutes(module *ast.Module, filePath string, forceInterpreter ...bool) 
 		printWarning("routes inject LLM but no provider is configured: " + llmEnvHint)
 	}
 
+	// Same for declared auth with no credential source: those routes deny
+	// every request, and the operator should hear that at startup.
+	warnUnconfiguredAuth(module)
+
 	// Try to compile routes if using compiler mode
 	if useCompiler {
 		c := compiler.NewCompilerWithOptLevel(compiler.OptBasic)

--- a/examples/llm-api/README.md
+++ b/examples/llm-api/README.md
@@ -1,0 +1,137 @@
+# Document Q&A API
+
+A document store with AI summarization and grounded question answering, showing the LLM provider used alongside the database provider in one file.
+
+## Features
+
+- LLM provider injection (`% ai: LLM`) next to database injection (`% db: Database`)
+- Provider configuration from the environment, so the source carries no credentials
+- API key authentication and rate limiting on the model-backed routes
+- Guards for missing documents and empty model responses
+- No client library, no async wiring, no glue code
+
+## Configuration
+
+The LLM provider is read from the environment at startup:
+
+| Variable | Purpose |
+|---|---|
+| `GLYPH_LLM_PROVIDER` | `anthropic`, `openai`, or `ollama` |
+| `GLYPH_LLM_API_KEY` | Provider credential. Not needed for `ollama` |
+| `GLYPH_LLM_BASE_URL` | Optional. Self-hosted or proxied endpoints |
+
+Starting without a provider configured prints a warning and the model-backed routes fail; the document routes still work.
+
+```bash
+export GLYPH_LLM_PROVIDER=anthropic
+export GLYPH_LLM_API_KEY=sk-ant-...
+glyph run examples/llm-api/main.glyph --port 8080
+```
+
+The database provider uses the built-in in-memory mock, so documents live only as long as the process.
+
+## API Endpoints
+
+### Create a Document
+```
+POST /documents
+```
+
+**Request:**
+```json
+{
+  "title": "Ponytail",
+  "body": "The best code is the code never written."
+}
+```
+
+**Response:** `201`
+```json
+{
+  "id": 1,
+  "title": "Ponytail",
+  "body": "The best code is the code never written."
+}
+```
+
+### Get a Document
+```
+GET /documents/:id
+```
+
+Returns the stored document, or `404` with `{"error": "document not found"}`.
+
+### Summarize a Document
+```
+POST /documents/:id/summarize
+```
+
+Sends the document body to the model, stores the summary, and returns it. Requires an API key and is limited to 20 requests per minute.
+
+**Response:** `200`
+```json
+{
+  "id": 1,
+  "title": "Ponytail",
+  "summary": "A two sentence summary produced by the model.",
+  "model": "claude-opus-5"
+}
+```
+
+Responds `404` if the document is missing and `502` if the model returns no content.
+
+### Ask a Question
+```
+POST /documents/:id/ask
+```
+
+Answers using only the stored document, and says so when the answer is not in it.
+
+**Request:**
+```json
+{
+  "question": "What is the best code?"
+}
+```
+
+**Response:** `200`
+```json
+{
+  "question": "What is the best code?",
+  "answer": "The code never written.",
+  "document_id": 1
+}
+```
+
+Responds `400` if `question` is missing, `404` if the document is missing, and `502` if the model returns no content.
+
+## Running Without a Provider Account
+
+Any endpoint that speaks the Ollama protocol works, including a local Ollama install or a stub:
+
+```bash
+export GLYPH_LLM_PROVIDER=ollama
+export GLYPH_LLM_BASE_URL=http://127.0.0.1:11434
+glyph run examples/llm-api/main.glyph --port 8080
+```
+
+## Authentication
+
+The two model-backed routes declare `+ auth(apikey)`, so they need a key list before they will serve anyone:
+
+```bash
+export GLYPH_API_KEYS="key-one,key-two"
+```
+
+Callers send it as `X-API-Key: key-one` or `Authorization: Bearer key-one`. Without the variable set, those routes reject every request with `401` and a warning is printed at startup - auth fails closed, so an unconfigured deployment denies rather than serves. That matters here because an open model-backed route spends tokens for anonymous callers.
+
+`+ auth(jwt)` elsewhere uses `GLYPH_JWT_SECRET` the same way.
+
+## Rate Limiting
+
+`+ ratelimit(20/min)` on the model-backed routes and `60/min` on the document routes are enforced per client IP; requests past the budget get `429`. No configuration needed.
+
+## Notes
+
+- The `Document` type declares `summary` as optional, so a document reads back fine before it has been summarized.
+- The database provider is the in-memory mock, so documents live only as long as the process.

--- a/pkg/server/middleware.go
+++ b/pkg/server/middleware.go
@@ -5,6 +5,7 @@ import (
 	"crypto/subtle"
 	"encoding/hex"
 	"log"
+	"net"
 	"net/http"
 	"runtime/debug"
 	"strings"
@@ -395,18 +396,20 @@ func SetTrustedProxies(proxies []string) {
 // When trustProxy is false (the default), only RemoteAddr is used,
 // preventing clients from spoofing their IP via headers.
 func getClientIP(r *http.Request, trustProxy bool) string {
+	// RemoteAddr is host:port, and the port differs on every connection.
+	// Callers use this as a client identity, so the port must not be part of
+	// it: keyed with the port, each request got its own rate-limit bucket and
+	// its own auth failure tracker, and neither limit could ever be reached.
+	remoteHost := r.RemoteAddr
+	if host, _, err := net.SplitHostPort(r.RemoteAddr); err == nil {
+		remoteHost = host
+	}
+
 	if trustProxy {
 		// If TrustedProxies is configured, only honor proxy headers from trusted IPs
 		tp := loadTrustedProxies()
-		if len(tp) > 0 {
-			remoteIP := r.RemoteAddr
-			// Strip port from RemoteAddr if present
-			if idx := strings.LastIndex(remoteIP, ":"); idx != -1 {
-				remoteIP = remoteIP[:idx]
-			}
-			if !tp[remoteIP] {
-				return r.RemoteAddr
-			}
+		if len(tp) > 0 && !tp[remoteHost] {
+			return remoteHost
 		}
 
 		if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
@@ -418,7 +421,7 @@ func getClientIP(r *http.Request, trustProxy bool) string {
 		}
 	}
 
-	return r.RemoteAddr
+	return remoteHost
 }
 
 // RateLimitMiddleware is a placeholder for rate limiting middleware

--- a/pkg/server/middleware_test.go
+++ b/pkg/server/middleware_test.go
@@ -821,7 +821,7 @@ func TestGetClientIP(t *testing.T) {
 			name:       "use RemoteAddr when no proxy headers",
 			remoteAddr: "192.168.1.100:12345",
 			trustProxy: true,
-			expectedIP: "192.168.1.100:12345",
+			expectedIP: "192.168.1.100",
 		},
 		{
 			name:          "prefer X-Forwarded-For over RemoteAddr from trusted proxy",
@@ -858,21 +858,21 @@ func TestGetClientIP(t *testing.T) {
 			xForwardedFor: "203.0.113.195",
 			xRealIP:       "203.0.113.100",
 			trustProxy:    true,
-			expectedIP:    "192.168.1.50:12345",
+			expectedIP:    "192.168.1.50",
 		},
 		{
 			name:          "ignore X-Forwarded-For when trustProxy is false",
 			remoteAddr:    "10.0.0.1:12345",
 			xForwardedFor: "203.0.113.195",
 			trustProxy:    false,
-			expectedIP:    "10.0.0.1:12345",
+			expectedIP:    "10.0.0.1",
 		},
 		{
 			name:       "ignore X-Real-IP when trustProxy is false",
 			remoteAddr: "10.0.0.1:12345",
 			xRealIP:    "203.0.113.100",
 			trustProxy: false,
-			expectedIP: "10.0.0.1:12345",
+			expectedIP: "10.0.0.1",
 		},
 	}
 


### PR DESCRIPTION
Stacked on #309. CI does not run on PRs targeting a non-main branch, so checks stay empty until that merges.

**A route declaring `+ auth(jwt)` served anyone.** Verified before this change, in both compiled and interpreted mode:

```
GET /protected   (declares + auth(jwt), no token sent)   -> 200 {"secret":"you should not see this"}
GET /limited     (declares + ratelimit(2/min), x5)       -> 200 200 200 200 200
```

The parser recorded both directives onto `ast.Route`, and `AuthMiddleware`, `BasicAuthMiddleware` and `RateLimitMiddleware` all existed in `pkg/server` - but nothing built them, and the dispatcher called `route.Handler` directly, discarding `Route.Middlewares` entirely. Same shape as the unwired providers: built, tested, never connected.

## What changed

- Build auth and rate-limit middleware from the declared directives, attached at registration for compiled and interpreted routes alike.
- Apply `Route.Middlewares` in the dispatcher.
- Credentials come from the environment, matching the provider pattern: `GLYPH_JWT_SECRET` for bearer tokens, `GLYPH_API_KEYS` for a comma-separated list accepted as `X-API-Key` or `Authorization: Bearer`.
- Rate limits convert to a per-minute budget, rounding up so an hourly budget never collapses to zero.

**Auth fails closed.** A route that declares auth with nothing configured to check it denies every request and warns at startup:

```
[WARNING] routes declare auth(jwt) but GLYPH_JWT_SECRET is not set: those routes will reject every request
```

Serving those routes is precisely the bug being fixed, so denying is the only safe default. The 401 body says nothing about server configuration; the startup warning tells the operator what to set.

## The limiter could not have worked anyway

`getClientIP` returned `RemoteAddr` **including the ephemeral port**, so every TCP connection produced a different identity - a fresh rate-limit bucket and a fresh auth failure counter each time. Neither limit nor the brute-force lockout could ever be reached, no matter how they were wired. It now returns the host alone, which fixes both.

Three `TestGetClientIP` expectations encoded the old port-bearing value and were updated; the subtests' intent (which source the IP comes from) is unchanged.

## Verification

| case | result |
|---|---|
| `auth(jwt)`, no token | 401 |
| `auth(jwt)`, wrong token | 401 |
| `auth(jwt)`, configured secret | 200 |
| `auth(apikey)` via `X-API-Key` and via `Bearer` | 200 both |
| `auth(apikey)`, unknown key | 401 |
| auth declared, nothing configured | 401 + startup warning |
| `ratelimit(2/min)`, 6 requests | 200 200 429 429 429 429 |
| `llm-api` summarize, anonymous | 401 instead of spending tokens |

New tests cover enforcement, the fail-closed property, both header forms, and the per-minute conversion for `sec`/`min`/`hour` including the rounding case. My first version of the rate-limit test rebuilt the chain per request and so never accumulated a bucket - fixed to build once, which is what makes the assertion meaningful.

`gofmt`, `go vet ./...`, full `go test ./...`, and the example harness all pass.

## Docs

`examples/llm-api/README.md` documents the key list and the fail-closed behaviour. The README's security bullet now says what is actually true and names the variables - it previously advertised "JWT auth, rate limiting" with neither enforced.

**The site still needs the same treatment.** glyphlang.dev advertises "JWT authentication, rate limiting" as built-in; that is now accurate but silent about configuration, and the claim was false while it was live. Worth a follow-up commit there.
