### PR TITLE
test: cover every notation symbol at runtime, and fix what that exposed

### DIFF
--- a/cmd/glyph/handlers.go
+++ b/cmd/glyph/handlers.go
@@ -189,6 +189,14 @@ func createCompiledRouteHandler(route *ast.Route, bytecode []byte, wsHub *websoc
 				var bodyMap map[string]interface{}
 				decoder := json.NewDecoder(limitedReader)
 				if err := decoder.Decode(&bodyMap); err == nil {
+					// Validate against the declared input type, as the
+					// interpreter path does. Without this a compiled route
+					// accepts any body at all: `< input: NewUser` was enforced
+					// only when a provider injection forced interpreter mode.
+					if err := validateCompiledInput(route, bodyMap); err != nil {
+						ctx.Request.Body.Close()
+						return sendClientError(ctx, err.Error())
+					}
 					vmInstance.SetLocal("input", interfaceToValue(bodyMap))
 				} else {
 					vmInstance.SetLocal("input", vm.NullValue{})
@@ -258,6 +266,16 @@ func createRouteHandler(route *ast.Route, interp *interpreter.Interpreter) serve
 		// Execute route body using the interpreter
 		response, err := executeRoute(route, ctx, interp)
 		if err != nil {
+			// Input validation and similar caller mistakes come back as an
+			// error alongside a response that already carries a 4xx status.
+			// Reporting those as 500 blames the server for a bad request and
+			// tells the caller nothing about what to fix.
+			if response != nil && response.StatusCode >= 400 && response.StatusCode < 500 {
+				ctx.StatusCode = response.StatusCode
+				ctx.ResponseWriter.Header().Set("Content-Type", "application/json")
+				ctx.ResponseWriter.WriteHeader(response.StatusCode)
+				return json.NewEncoder(ctx.ResponseWriter).Encode(response.Body)
+			}
 			return writeInternalError(ctx, fmt.Errorf("route execution error: %w", err))
 		}
 
@@ -355,7 +373,10 @@ func executeRoute(route *ast.Route, ctx *server.Context, interp *interpreter.Int
 	// Use ExecuteRoute instead of ExecuteRouteSimple to handle request body
 	response, err := interp.ExecuteRoute(route, request)
 	if err != nil {
-		return nil, fmt.Errorf("route execution failed: %w", err)
+		// Keep the response: for caller mistakes such as failed input
+		// validation the interpreter returns a 4xx response alongside the
+		// error, and the handler uses it instead of reporting a 500.
+		return response, fmt.Errorf("route execution failed: %w", err)
 	}
 
 	return response, nil
@@ -731,6 +752,59 @@ func newMongoDBHandler() interface{} {
 	}
 	printInfo(fmt.Sprintf("Connected to MongoDB at %s (database %s)", uri, dbName))
 	return handler
+}
+
+// compiledTypeDefs holds the module's type definitions for the compiled route
+// path, which has no interpreter to consult. Set once per server start, before
+// any request is served.
+var compiledTypeDefs = map[string]ast.TypeDef{}
+
+// setCompiledTypeDefs records the module's types so compiled routes can
+// validate request bodies against a declared input type.
+func setCompiledTypeDefs(module *ast.Module) {
+	defs := make(map[string]ast.TypeDef)
+	for _, item := range module.Items {
+		if typeDef, ok := item.(*ast.TypeDef); ok {
+			defs[typeDef.Name] = *typeDef
+		}
+	}
+	compiledTypeDefs = defs
+}
+
+// validateCompiledInput checks a decoded request body against the route's
+// declared input type, mirroring what the interpreter does at
+// interpreter.go:558. Fields carrying a default are not treated as required,
+// so this does not reject bodies the interpreter would accept.
+func validateCompiledInput(route *ast.Route, body map[string]interface{}) error {
+	if route.InputType == nil {
+		return nil
+	}
+	named, ok := route.InputType.(ast.NamedType)
+	if !ok {
+		return nil
+	}
+	typeDef, exists := compiledTypeDefs[named.Name]
+	if !exists {
+		return nil
+	}
+
+	checker := interpreter.NewTypeChecker()
+	checker.SetTypeDefs(compiledTypeDefs)
+	if err := checker.ValidateObjectAgainstTypeDef(body, typeDef); err != nil {
+		return fmt.Errorf("input validation failed: %v", err)
+	}
+	return nil
+}
+
+// sendClientError reports a caller mistake with a 4xx, distinct from the
+// generic 500 used for server faults.
+func sendClientError(ctx *server.Context, message string) error {
+	ctx.StatusCode = http.StatusBadRequest
+	ctx.ResponseWriter.Header().Set("Content-Type", "application/json")
+	ctx.ResponseWriter.WriteHeader(http.StatusBadRequest)
+	return json.NewEncoder(ctx.ResponseWriter).Encode(map[string]interface{}{
+		"error": message,
+	})
 }
 
 // writeInternalError logs the full error server-side and sends a generic 500 to

--- a/cmd/glyph/main.go
+++ b/cmd/glyph/main.go
@@ -115,6 +115,11 @@ Example:
 		Args: cobra.MinimumNArgs(2),
 		RunE: runExec,
 	}
+	// Flags after the command name belong to the .glyph command being run, not
+	// to `exec` itself. Without this, the documented form
+	// `glyph exec app.glyph greet --name=ada` fails with "unknown flag: --name"
+	// and callers have to discover an undocumented `--` separator.
+	execCmd.Flags().SetInterspersed(false)
 
 	// List commands - list all commands in a .glyph file
 	var listCmdsCmd = &cobra.Command{

--- a/cmd/glyph/routes.go
+++ b/cmd/glyph/routes.go
@@ -54,6 +54,48 @@ func listenAddr(port int) string {
 	return net.JoinHostPort(host, strconv.Itoa(port))
 }
 
+// warnInertDeclarations reports declarations the running server does not act
+// on. Cron tasks, event handlers and queue workers are parsed, exported to the
+// IR and listed by `glyph commands`, but nothing schedules, emits or consumes
+// them: there is no scheduler, EmitEvent has no caller, and no queue is drained.
+//
+// Silence is exactly what made the unwired providers and the unenforced auth
+// directives so expensive to find, so these say so at startup rather than
+// leaving an operator to conclude from the absence of output that a task ran.
+func warnInertDeclarations(module *ast.Module) {
+	var crons, events, queues int
+	for _, item := range module.Items {
+		switch item.(type) {
+		case *ast.CronTask:
+			crons++
+		case *ast.EventHandler:
+			events++
+		case *ast.QueueWorker:
+			queues++
+		}
+	}
+
+	for _, decl := range []struct {
+		count int
+		what  string
+		why   string
+	}{
+		{crons, "cron task", "no scheduler runs them"},
+		{events, "event handler", "nothing emits events at runtime"},
+		{queues, "queue worker", "no queue is consumed"},
+	} {
+		if decl.count == 0 {
+			continue
+		}
+		plural := "s"
+		if decl.count == 1 {
+			plural = ""
+		}
+		printWarning(fmt.Sprintf("%d %s%s declared but %s: they will not run",
+			decl.count, decl.what, plural, decl.why))
+	}
+}
+
 // setupRoutes handles the common logic of determining execution mode, compiling routes,
 // and setting up the router. Used by both startServer and startDevServerInternal.
 // filePath is the path to the source file, used for resolving relative module imports.
@@ -85,6 +127,13 @@ func setupRoutes(module *ast.Module, filePath string, forceInterpreter ...bool) 
 	// Same for declared auth with no credential source: those routes deny
 	// every request, and the operator should hear that at startup.
 	warnUnconfiguredAuth(module)
+
+	// And for declarations the server does not act on at all.
+	warnInertDeclarations(module)
+
+	// Compiled routes have no interpreter to consult, so hand them the type
+	// definitions they need to validate request bodies.
+	setCompiledTypeDefs(module)
 
 	// Try to compile routes if using compiler mode
 	if useCompiler {

--- a/pkg/interpreter/typechecker.go
+++ b/pkg/interpreter/typechecker.go
@@ -4,6 +4,7 @@ import (
 	. "github.com/glyphlang/glyph/pkg/ast"
 
 	"fmt"
+	"math"
 	"reflect"
 	"strings"
 )
@@ -127,6 +128,16 @@ func (tc *TypeChecker) CheckType(value interface{}, expectedType Type) error {
 	// return type.
 	if value == nil {
 		return nil
+	}
+
+	// JSON has a single number type, so every number in a request body decodes
+	// to float64. Without this, an `int` field rejects the perfectly ordinary
+	// body {"id": 1} with "expected int, got float". A value with a fractional
+	// part is still a mismatch.
+	if _, wantInt := expectedType.(IntType); wantInt {
+		if f, ok := value.(float64); ok && f == math.Trunc(f) && !math.IsInf(f, 0) {
+			return nil
+		}
 	}
 
 	actualType := GetRuntimeType(value)

--- a/tests/symbols_runtime_test.go
+++ b/tests/symbols_runtime_test.go
@@ -1,0 +1,284 @@
+package tests
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The notation's symbol vocabulary is what the spec leads with, but several
+// symbols turned out to be parsed and then ignored at runtime - providers,
+// auth and ratelimit each shipped that way. These tests exercise one small
+// program per symbol and assert something observable, so a symbol that stops
+// doing anything fails here instead of being discovered in production.
+//
+// Symbols that do nothing yet are skipped with the reason, the same convention
+// examples_runtime_test.go uses for broken examples.
+
+var inertSymbols = map[string]string{
+	"*": "cron tasks are parsed and listed but no scheduler runs them",
+	"~": "event handlers are registered but EmitEvent has no caller at runtime",
+	"&": "queue workers are registered but no queue is consumed",
+}
+
+// writeProgram puts a .glyph program in a temp dir and returns its path.
+func writeProgram(t *testing.T, source string) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "main.glyph")
+	if err := os.WriteFile(path, []byte(source), 0o600); err != nil {
+		t.Fatalf("writing program: %v", err)
+	}
+	return path
+}
+
+// serve boots a program and returns a request helper plus the server log.
+func serve(t *testing.T, binary, source string) (func(method, path, body string) (int, string), func() string) {
+	t.Helper()
+
+	file := writeProgram(t, source)
+	port := freePort(t)
+	stop, logs := startExample(t, binary, file, port)
+	t.Cleanup(stop)
+
+	request := func(method, path, body string) (int, string) {
+		t.Helper()
+
+		var reader *strings.Reader
+		if body == "" {
+			reader = strings.NewReader("")
+		} else {
+			reader = strings.NewReader(body)
+		}
+		req, err := http.NewRequest(method, fmt.Sprintf("http://127.0.0.1:%d%s", port, path), reader)
+		if err != nil {
+			t.Fatalf("building request: %v", err)
+		}
+		req.Header.Set("Content-Type", "application/json")
+
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("%s %s: %v\nserver log:\n%s", method, path, err, logs())
+		}
+		defer resp.Body.Close()
+
+		var out bytes.Buffer
+		_, _ = out.ReadFrom(resp.Body)
+		return resp.StatusCode, out.String()
+	}
+
+	return request, logs
+}
+
+// TestSymbolRoutesAndReturns covers @ (route), : (type), $ (binding) and
+// > (return, with an explicit status).
+func TestSymbolRoutesAndReturns(t *testing.T) {
+	if testing.Short() {
+		t.Skip("boots a server; skipped in -short")
+	}
+
+	request, _ := serve(t, buildGlyphBinary(t), `: Reply {
+  message: str!
+}
+
+@ GET /hello -> Reply {
+  $ greeting = "hello"
+  > {message: greeting} :: 201
+}`)
+
+	status, body := request("GET", "/hello", "")
+	if status != 201 {
+		t.Errorf("explicit status suffix ignored: got %d, want 201", status)
+	}
+	if !strings.Contains(body, `"message":"hello"`) {
+		t.Errorf("binding did not reach the response: %s", body)
+	}
+}
+
+// TestSymbolGuard covers ? used as a guard, which must short-circuit with the
+// declared status rather than running the rest of the route.
+func TestSymbolGuard(t *testing.T) {
+	if testing.Short() {
+		t.Skip("boots a server; skipped in -short")
+	}
+
+	request, _ := serve(t, buildGlyphBinary(t), `@ GET /guarded {
+  $ allowed = false
+  ? allowed :: 403 "not allowed"
+  > {reached: true}
+}`)
+
+	status, body := request("GET", "/guarded", "")
+	if status != 403 {
+		t.Errorf("guard did not fire: got %d, want 403\nbody: %s", status, body)
+	}
+	if strings.Contains(body, "reached") {
+		t.Errorf("guard did not short-circuit the route body: %s", body)
+	}
+}
+
+// TestSymbolInputValidation covers < (expects), which must reject a body that
+// does not satisfy the declared type.
+func TestSymbolInputValidation(t *testing.T) {
+	if testing.Short() {
+		t.Skip("boots a server; skipped in -short")
+	}
+
+	request, _ := serve(t, buildGlyphBinary(t), `: NewUser {
+  name: str!
+  age: int!
+}
+
+@ POST /users {
+  < input: NewUser
+  > {name: input.name}
+}`)
+
+	status, body := request("POST", "/users", `{"name":"ada","age":36}`)
+	if status != 200 {
+		t.Errorf("valid body rejected: got %d\nbody: %s", status, body)
+	}
+
+	status, body = request("POST", "/users", `{"name":"ada"}`)
+	if status < 400 || status >= 500 {
+		t.Errorf("body missing a required field should be a client error: got %d\nbody: %s", status, body)
+	}
+}
+
+// TestSymbolMiddleware covers + for both directives it supports, which were
+// inert until they were wired: an unconfigured auth must deny, and a rate
+// limit must reject once the budget is spent.
+func TestSymbolMiddleware(t *testing.T) {
+	if testing.Short() {
+		t.Skip("boots a server; skipped in -short")
+	}
+
+	request, _ := serve(t, buildGlyphBinary(t), `@ GET /guarded {
+  + auth(apikey)
+  > {ok: true}
+}
+
+@ GET /limited {
+  + ratelimit(2/min)
+  > {ok: true}
+}`)
+
+	if status, body := request("GET", "/guarded", ""); status != 401 {
+		t.Errorf("auth(apikey) with no keys configured must deny: got %d\nbody: %s", status, body)
+	}
+
+	statuses := make([]int, 0, 3)
+	for i := 0; i < 3; i++ {
+		status, _ := request("GET", "/limited", "")
+		statuses = append(statuses, status)
+	}
+	if statuses[0] != 200 || statuses[1] != 200 || statuses[2] != 429 {
+		t.Errorf("ratelimit(2/min) should allow two then reject: got %v", statuses)
+	}
+}
+
+// TestSymbolProviderInjection covers % by writing through the mock database
+// and reading the record back.
+func TestSymbolProviderInjection(t *testing.T) {
+	if testing.Short() {
+		t.Skip("boots a server; skipped in -short")
+	}
+
+	request, _ := serve(t, buildGlyphBinary(t), `: Note {
+  id: int!
+  body: str!
+}
+
+@ POST /notes {
+  < input: Note
+  % db: Database
+  $ saved = db.notes.Create(input)
+  > saved :: 201
+}
+
+@ GET /notes/:id {
+  % db: Database
+  $ note = db.notes.Get(id)
+  ? note != null :: 404 "not found"
+  > note
+}`)
+
+	if status, body := request("POST", "/notes", `{"id":1,"body":"written"}`); status != 201 {
+		t.Fatalf("provider write failed: got %d\nbody: %s", status, body)
+	}
+
+	status, body := request("GET", "/notes/1", "")
+	if status != 200 {
+		t.Fatalf("provider read failed: got %d\nbody: %s", status, body)
+	}
+	if !strings.Contains(body, "written") {
+		t.Errorf("record did not round-trip through the provider: %s", body)
+	}
+}
+
+// TestSymbolCommand covers ! by invoking a declared command through
+// `glyph exec`, which needs no server.
+func TestSymbolCommand(t *testing.T) {
+	if testing.Short() {
+		t.Skip("runs the binary; skipped in -short")
+	}
+
+	binary := buildGlyphBinary(t)
+	file := writeProgram(t, `! greet name: str! {
+  > {message: "hello, " + name}
+}`)
+
+	out, err := exec.Command(binary, "exec", file, "greet", "--name=ada").CombinedOutput()
+	if err != nil {
+		t.Fatalf("glyph exec failed: %v\n%s", err, out)
+	}
+	if !strings.Contains(string(out), "hello, ada") {
+		t.Errorf("command did not run: %s", out)
+	}
+}
+
+// TestInertSymbolsWarnAtStartup is the honest half. Cron tasks, event handlers
+// and queue workers do nothing at runtime, so the one behaviour to guarantee is
+// that the server says so instead of implying the work is scheduled.
+func TestInertSymbolsWarnAtStartup(t *testing.T) {
+	if testing.Short() {
+		t.Skip("boots a server; skipped in -short")
+	}
+
+	for symbol, reason := range inertSymbols {
+		t.Logf("symbol %q is inert: %s", symbol, reason)
+	}
+
+	_, logs := serve(t, buildGlyphBinary(t), `* "0 0 * * *" nightly {
+  $ x = 1
+}
+
+~ "user.created" {
+  $ y = 2
+}
+
+& "emails" {
+  $ z = 3
+}
+
+@ GET /ping {
+  > {ok: true}
+}`)
+
+	output := logs()
+	for _, expected := range []string{
+		"cron task declared",
+		"event handler declared",
+		"queue worker declared",
+	} {
+		if !strings.Contains(output, expected) {
+			t.Errorf("startup did not warn %q; an operator would assume it runs\nserver log:\n%s",
+				expected, output)
+		}
+	}
+}


### PR DESCRIPTION
Part 1 of the "declared but never wired" sweep. Branches from main - no stack this time.

Providers (#306, #308), the 500 status (#305) and `auth`/`ratelimit` (#310) each shipped parsed-but-ignored. Nothing checked that a symbol in the vocabulary actually *does* anything, so the next one would have shipped the same way. `tests/symbols_runtime_test.go` now runs one small program per symbol and asserts something observable: a guard short-circuits, a provider round-trips a record, `>` honours its status suffix, `!` runs through `glyph exec`.

## Four bugs the tests exposed

**`glyph exec` did not work as documented.** The form in `docs/CLI.md`, the README, and the command's own help text:

```
$ glyph exec examples/cli-demo/main.glyph hello --name="Alice"
Error: unknown flag: --name
```

Callers had to discover an undocumented `--` separator. Flags after the command name now belong to the command being run.

**A JSON body could not satisfy an `int` field.** JSON has one number type, so `{"id": 1}` decodes to `float64` and every `int` field rejected it:

```
route execution failed: field id: type mismatch: expected int, got float
```

Integral values are now accepted. `{"id": 1.5}` is still a mismatch.

**Input validation failures answered 500.** The interpreter returns a 4xx response alongside the error and the handler threw it away, so a caller's malformed body was reported as a server fault carrying no hint:

```
before: 500 {"error":"Internal server error"}
after:  400 {"error":"input validation failed: missing required field: id"}
```

Genuine faults still return 500 - verified with a route that fails at runtime.

**`< input: T` was not enforced in compiled mode at all.** Validation ran only when a provider injection forced interpreter mode, so a route without providers accepted any body whatsoever. Compiled routes now validate against the declared type, using the same `ValidateObjectAgainstTypeDef` the interpreter uses. Fields carrying a default stay optional, so nothing the interpreter accepts is newly rejected.

## Three symbols that cannot be tested into working

`*` cron has no scheduler anywhere in the repo, `~` events have no runtime emit path (`EmitEvent` has no caller), and `&` queue workers are never consumed. They are parsed, exported to the IR, and listed by `glyph commands`, which is exactly the shape that made the earlier bugs expensive to find. They now say so:

```
[WARNING] 1 cron task declared but no scheduler runs them: they will not run
[WARNING] 1 event handler declared but nothing emits events at runtime: they will not run
[WARNING] 1 queue worker declared but no queue is consumed: they will not run
```

A test asserts those warnings appear, so removing one without implementing the feature fails. Building a scheduler is a feature with real decisions - missed runs, timezones, overlap - and belongs in its own change.

## Verification

- Symbol suite passes; each inert symbol is documented with its reason in `inertSymbols`.
- All 44 examples validate; the #309 examples harness still green in 2.6s.
- Documented `exec` form verified against the shipped `cli-demo`.
- `{"id":1}` -> 201, `{"id":1.5}` -> 400, missing required field -> 400, runtime fault -> 500, all against a running server.
- `gofmt`, `go vet ./...`, full `go test ./...` clean.
