### PR TITLE
fix: bind loopback by default instead of every interface

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,9 @@ RUN chown -R glyph:glyph /app
 # Switch to non-root user
 USER glyph
 
-# Expose default port
+# Expose default port. The server binds loopback unless told otherwise, which
+# would make it unreachable from outside the container.
+ENV GLYPH_HOST=0.0.0.0
 EXPOSE 8080
 
 # Health check

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -22,7 +22,9 @@ RUN go mod download
 # Copy project files
 COPY . .
 
-# Expose ports
+# Expose ports. The server binds loopback unless told otherwise, which would
+# make it unreachable from outside the container.
+ENV GLYPH_HOST=0.0.0.0
 EXPOSE 8080
 
 # Development command with hot-reload

--- a/cmd/glyph/routes.go
+++ b/cmd/glyph/routes.go
@@ -2,9 +2,11 @@ package main
 
 import (
 	"fmt"
+	"net"
 	"net/http"
 	"os"
 	"path/filepath"
+	"strconv"
 	"time"
 
 	"github.com/glyphlang/glyph/pkg/ast"
@@ -31,6 +33,25 @@ func moduleInjectsLLM(module *ast.Module) bool {
 		}
 	}
 	return false
+}
+
+// envHost overrides the interface the server binds to. Containers and hosts
+// that must serve other machines set it to "0.0.0.0".
+const envHost = "GLYPH_HOST"
+
+// listenAddr returns the address to bind, defaulting to loopback.
+//
+// Binding every interface exposes the server to the local network the moment
+// it starts, which is the wrong default for a runtime whose `+ auth` denies
+// nothing until credentials are configured. On Windows it also raises a
+// Defender Firewall prompt on every new binary, which `go test` produces on
+// each run.
+func listenAddr(port int) string {
+	host := os.Getenv(envHost)
+	if host == "" {
+		host = "127.0.0.1"
+	}
+	return net.JoinHostPort(host, strconv.Itoa(port))
 }
 
 // setupRoutes handles the common logic of determining execution mode, compiling routes,
@@ -187,7 +208,7 @@ func startServer(filePath string, port int, forceInterpreter bool) (*http.Server
 	}
 
 	srv := &http.Server{
-		Addr:           fmt.Sprintf(":%d", port),
+		Addr:           listenAddr(port),
 		Handler:        loggingMiddleware(mux),
 		ReadTimeout:    15 * time.Second,
 		WriteTimeout:   15 * time.Second,
@@ -201,7 +222,7 @@ func startServer(filePath string, port int, forceInterpreter bool) (*http.Server
 		if !useCompiler {
 			mode = "interpreted"
 		}
-		printSuccess(fmt.Sprintf("Server listening on http://localhost:%d (%s mode)", port, mode))
+		printSuccess(fmt.Sprintf("Server listening on http://%s (%s mode)", listenAddr(port), mode))
 		printInfo("Press Ctrl+C to stop")
 		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 			printError(fmt.Errorf("server error: %w", err))

--- a/cmd/glyph/server.go
+++ b/cmd/glyph/server.go
@@ -107,7 +107,7 @@ func (m *hotReloadManager) startDevServerInternal() (*http.Server, error) {
 	}
 
 	srv := &http.Server{
-		Addr:           fmt.Sprintf(":%d", m.port),
+		Addr:           listenAddr(m.port),
 		Handler:        loggingMiddleware(mux),
 		ReadTimeout:    15 * time.Second,
 		WriteTimeout:   15 * time.Second,
@@ -121,7 +121,7 @@ func (m *hotReloadManager) startDevServerInternal() (*http.Server, error) {
 		if !useCompiler {
 			mode = "interpreted"
 		}
-		printSuccess(fmt.Sprintf("Dev server listening on http://localhost:%d (%s mode)", m.port, mode))
+		printSuccess(fmt.Sprintf("Dev server listening on http://%s (%s mode)", listenAddr(m.port), mode))
 		printInfo("Live reload enabled at /__livereload")
 		printInfo("Press Ctrl+C to stop")
 		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {

--- a/deploy/DEPLOYMENT_GUIDE.md
+++ b/deploy/DEPLOYMENT_GUIDE.md
@@ -60,6 +60,7 @@ docker run -it \
 
 | Variable | Description | Default |
 |----------|-------------|---------|
+| `GLYPH_HOST` | Interface to bind. Must be `0.0.0.0` to be reachable from outside the container; the shipped Dockerfiles set it | `127.0.0.1` |
 | `Glyph_ENV` | Environment (development/production) | production |
 | `Glyph_PORT` | HTTP server port | 8080 |
 | `Glyph_LOG_LEVEL` | Log level (debug/info/warn/error) | info |

--- a/deploy/kubernetes/deployment.yaml
+++ b/deploy/kubernetes/deployment.yaml
@@ -36,6 +36,10 @@ spec:
           containerPort: 8080
           protocol: TCP
         env:
+        # Bind all interfaces: the default is loopback, which no probe or
+        # Service can reach.
+        - name: GLYPH_HOST
+          value: "0.0.0.0"
         - name: Glyph_ENV
           value: "production"
         - name: Glyph_PORT

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -42,7 +42,7 @@ glyph dev examples/hello-world/main.glyph
 ```bash
 $ glyph dev examples/hello-world/main.glyph -p 8080 --open
 [INFO] Starting development server on port 8080...
-[SUCCESS] Dev server listening on http://localhost:8080 (compiled mode)
+[SUCCESS] Dev server listening on http://127.0.0.1:8080 (compiled mode)
 [INFO] Live reload enabled at /__livereload
 [INFO] Watching examples/hello-world/main.glyph for changes...
 [INFO] Opened http://localhost:8080 in browser
@@ -88,7 +88,7 @@ glyph run examples/rest-api/main.glyph
 # Run source file (compiles to bytecode first)
 $ glyph run examples/rest-api/main.glyph
 [INFO] Compiling and running examples/rest-api/main.glyph...
-[SUCCESS] Server listening on http://localhost:3000 (compiled mode)
+[SUCCESS] Server listening on http://127.0.0.1:3000 (compiled mode)
 [INFO] Press Ctrl+C to stop
 
 # Run pre-compiled bytecode
@@ -99,7 +99,7 @@ $ glyph run build/app.glyphc --bytecode
 # Force interpreter mode
 $ glyph run examples/rest-api/main.glyph --interpret
 [INFO] Running examples/rest-api/main.glyph with interpreter...
-[SUCCESS] Server listening on http://localhost:3000
+[SUCCESS] Server listening on http://127.0.0.1:3000
 ```
 
 ### `glyph compile <file>`
@@ -968,6 +968,7 @@ GlyphLang applications can be configured via environment variables.
 
 | Variable | Description | Default |
 |----------|-------------|---------|
+| `GLYPH_HOST` | Interface `glyph run` and `glyph dev` bind to. Set to `0.0.0.0` to serve other machines, as containers must | `127.0.0.1` |
 | `Glyph_ENV` | Environment (development/production) | `production` |
 | `Glyph_PORT` | HTTP server port | `8080` |
 | `Glyph_LOG_LEVEL` | Log level (debug/info/warn/error) | `info` |

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -137,7 +137,7 @@ You will see output like:
 
 ```
 [INFO] Starting development server on port 3000...
-[SUCCESS] Dev server listening on http://localhost:3000 (compiled mode)
+[SUCCESS] Dev server listening on http://127.0.0.1:3000 (compiled mode)
 [INFO] Watching main.glyph for changes...
 [INFO] Press Ctrl+C to stop
 ```


### PR DESCRIPTION
Both server paths bound `":port"`, which means `0.0.0.0` - every interface.

## The firewall prompts

A program listening on a non-loopback address is exactly what the Windows Defender Firewall prompt exists for, and it asks once per binary. `buildGlyphBinary` builds into `t.TempDir()`, so every `go test` run produced a binary at a path Windows had never seen, and the harness starts one server per example. That is a round of prompts per run, each one blocking until answered.

Binding loopback raises no prompt at all, so the harness runs unattended. No firewall rule, no exclusion, no admin rights.

## The default was also wrong on its own terms

`glyph run` published to the local network the moment it started. For a runtime whose `+ auth` directives enforced nothing until #310, and whose credentials are still unset on a fresh machine, the reachable surface was larger than the surface being protected. Loopback is the same default `vite` and `next dev` settled on, for the same reason.

## Override

`GLYPH_HOST` selects the interface:

```
$ glyph run app.glyph --port 3000
[SUCCESS] Server listening on http://127.0.0.1:3000 (compiled mode)

$ GLYPH_HOST=0.0.0.0 glyph run app.glyph --port 3000
[SUCCESS] Server listening on http://0.0.0.0:3000 (compiled mode)
```

A container that binds loopback is unreachable from its own Service and health probes, so `Dockerfile`, `Dockerfile.dev` and `deploy/kubernetes/deployment.yaml` set it. The startup line prints the address actually bound rather than assuming `localhost`, so an operator who needs the override can see that they do not have it.

Env-only, no `--host` flag: the flag would have to thread through `startServer` and the dev server manager, and the env var covers containers and shells alike. Worth adding when someone wants to run two hosts from one shell.

## Verification

- `netstat` confirms `127.0.0.1:PORT` by default and `0.0.0.0:PORT` under `GLYPH_HOST=0.0.0.0`; served a request over both.
- Examples harness and the full suite green; `gofmt`, `go vet ./...` clean.
- Docs and deployment guide updated, including the sample output they show.

## Noticed, not fixed

`Glyph_ENV`, `Glyph_PORT` and `Glyph_LOG_LEVEL` are documented in `docs/CLI.md`, `deploy/DEPLOYMENT_GUIDE.md` and the k8s manifest, and appear nowhere in the Go source. Same shape as the bugs the sweep has been clearing: documented, configured by users, read by nothing. Left alone here because deciding between implementing them and deleting them is a product call.
