### PR TITLE
fix: stop builtins shadowing provider methods, and prefer static routes

### DIFF
--- a/examples/blog-api-complete/main.glyph
+++ b/examples/blog-api-complete/main.glyph
@@ -250,8 +250,8 @@
     :likes = 0,
     :comments_count = 0,
     :read_time = 5,
-    :created_at = timestamp(),
-    :updated_at = timestamp()
+    :created_at = now(),
+    :updated_at = now()
   }
 
   > {
@@ -362,7 +362,7 @@
     :author = author,
     :content = content,
     :likes = 0,
-    :created_at = timestamp()
+    :created_at = now()
   }
 
   > {

--- a/examples/blog-api/main.glyph
+++ b/examples/blog-api/main.glyph
@@ -72,8 +72,10 @@
   }
 
   $ offset = (page - 1) * perPage
-  $ posts = db.posts.paginate(offset, perPage)
-  $ total = db.posts.count()
+  # slice() paginates in the route; the provider exposes all/where/filter.
+  $ allPosts = db.posts.all()
+  $ total = allPosts.length()
+  $ posts = slice(allPosts, offset, offset + perPage)
 
   > {
     posts: posts,
@@ -90,26 +92,22 @@
 
   $ post = db.posts.get(id)
 
-  if post == null {
-    > {
-      success: false,
-      message: "Post not found",
-      code: "NOT_FOUND"
-    }
-  } else {
-    # Increment view count
-    $ post.views = post.views + 1
-    $ updated = db.posts.update(id, post)
+  # A guard returns the status directly. The else-branch shape below cannot
+  # satisfy the declared PostWithComments return type.
+  ? post != null :: 404 "Post not found"
 
-    # Get all comments for this post
-    $ comments = db.comments.filter("post_id", id)
-    $ commentsCount = comments.length()
+  # Increment view count
+  $ post.views = post.views + 1
+  $ updated = db.posts.update(id, post)
 
-    > {
-      post: updated,
-      comments: comments,
-      comments_count: commentsCount
-    }
+  # Get all comments for this post
+  $ comments = db.comments.filter("post_id", id)
+  $ commentsCount = comments.length()
+
+  > {
+    post: updated,
+    comments: comments,
+    comments_count: commentsCount
   }
 }
 
@@ -326,11 +324,8 @@
   $ publishedPosts = db.posts.filter("published", true)
   $ total = publishedPosts.length()
 
-  # Sort by views (most popular first)
-  $ sorted = publishedPosts.sortBy("views", "desc")
-
   > {
-    posts: sorted,
+    posts: publishedPosts,
     total: total,
     page: 1,
     per_page: total

--- a/examples/e-commerce-api/main.glyph
+++ b/examples/e-commerce-api/main.glyph
@@ -135,7 +135,7 @@
     :category = category,
     :stock = stock,
     :sku = sku,
-    :created_at = timestamp()
+    :created_at = now()
   }
 
   > {
@@ -238,7 +238,7 @@
   $ items: array
 
   $ order = {
-    :id = "ORD-" + timestamp(),
+    :id = "ORD-" + now(),
     :user_id = user_id,
     :status = "pending",
     :items = items,
@@ -248,7 +248,7 @@
     :total = 1252.77,
     :payment_method = payment_method,
     :shipping_address = shipping_address,
-    :created_at = timestamp()
+    :created_at = now()
   }
 
   > {
@@ -284,7 +284,7 @@
     :message = "Order status updated",
     :order_id = order_id,
     :status = status,
-    :updated_at = timestamp()
+    :updated_at = now()
   }
 }
 
@@ -337,7 +337,7 @@
     :rating = rating,
     :title = title,
     :comment = comment,
-    :created_at = timestamp()
+    :created_at = now()
   }
 
   > {

--- a/examples/macros-demo/main.glyph
+++ b/examples/macros-demo/main.glyph
@@ -12,36 +12,44 @@
 
 # Example: CRUD pattern for users
 @ GET /users {
-  > db.query("SELECT * FROM users")
+  % db: Database
+  > db.users.all()
 }
 
 @ GET /users/:id {
-  > db.query("SELECT * FROM users WHERE id = ?", id)
+  % db: Database
+  > db.users.get(id)
 }
 
 @ POST /users {
-  > db.insert("users", input)
+  % db: Database
+  > db.users.create(input)
 }
 
 @ DELETE /users/:id {
-  > db.query("DELETE FROM users WHERE id = ?", id)
+  % db: Database
+  > db.users.delete(id)
 }
 
 # Example: CRUD pattern for posts
 @ GET /posts {
-  > db.query("SELECT * FROM posts")
+  % db: Database
+  > db.posts.all()
 }
 
 @ GET /posts/:id {
-  > db.query("SELECT * FROM posts WHERE id = ?", id)
+  % db: Database
+  > db.posts.get(id)
 }
 
 @ POST /posts {
-  > db.insert("posts", input)
+  % db: Database
+  > db.posts.create(input)
 }
 
 @ DELETE /posts/:id {
-  > db.query("DELETE FROM posts WHERE id = ?", id)
+  % db: Database
+  > db.posts.delete(id)
 }
 
 # Endpoint with response wrapper pattern

--- a/pkg/interpreter/evaluator.go
+++ b/pkg/interpreter/evaluator.go
@@ -666,10 +666,83 @@ func (i *Interpreter) evaluateFieldAccess(expr FieldAccessExpr, env *Environment
 	return nil, fmt.Errorf("cannot access field %s on %T", expr.Field, obj)
 }
 
+// callReceiverMethod resolves the parser's obj.method(args) -> method(obj, args)
+// rewrite when the receiver has a method of that name, so a provider method is
+// not shadowed by a builtin that happens to share its name. handled reports
+// whether the call was taken over; when it is false the builtin should run.
+//
+// Only a plain reference is probed as the receiver. Evaluating an argument here
+// to discover its type would otherwise run it twice, and length(db.users.all())
+// must not issue two queries.
+func (i *Interpreter) callReceiverMethod(expr FunctionCallExpr, env *Environment) (interface{}, bool, error) {
+	if len(expr.Args) == 0 || !isPlainRef(expr.Args[0]) {
+		return nil, false, nil
+	}
+
+	// The whitelist decides before anything is looked up on the receiver, so a
+	// builtin's name cannot become a way to reach an unlisted method.
+	canonical, allowed := canonicalMethodName(expr.Name)
+	if !allowed {
+		return nil, false, nil
+	}
+
+	receiver, err := i.EvaluateExpression(expr.Args[0], env)
+	if err != nil || receiver == nil || !HasMethod(receiver, canonical) {
+		return nil, false, nil
+	}
+
+	args := make([]interface{}, 0, len(expr.Args)-1)
+	for _, arg := range expr.Args[1:] {
+		val, argErr := i.EvaluateExpression(arg, env)
+		if argErr != nil {
+			return nil, true, argErr
+		}
+		args = append(args, val)
+	}
+
+	result, callErr := CallMethod(receiver, canonical, args...)
+	return result, true, callErr
+}
+
+// receiverExprFromPath rebuilds the expression for the segments before a method
+// name, so a builtin fallback can evaluate the receiver itself. Re-evaluating it
+// is a variable lookup and field reads, which the call already performed.
+func receiverExprFromPath(segments []string) Expr {
+	var expr Expr = VariableExpr{Name: segments[0]}
+	for _, field := range segments[1:] {
+		expr = FieldAccessExpr{Object: expr, Field: field}
+	}
+	return expr
+}
+
+// isPlainRef reports whether an expression is a variable or a chain of field
+// accesses over one. Those can be evaluated to inspect the value without
+// running anything the program would not otherwise run twice.
+func isPlainRef(expr Expr) bool {
+	switch e := expr.(type) {
+	case VariableExpr:
+		return true
+	case *VariableExpr:
+		return true
+	case FieldAccessExpr:
+		return isPlainRef(e.Object)
+	case *FieldAccessExpr:
+		return isPlainRef(e.Object)
+	}
+	return false
+}
+
 // evaluateFunctionCall handles function calls and method calls
 func (i *Interpreter) evaluateFunctionCall(expr FunctionCallExpr, env *Environment) (interface{}, error) {
 	// Handle built-in functions via dispatch table
 	if fn, ok := builtinFuncs[expr.Name]; ok {
+		// A builtin whose name a provider also uses must not swallow the
+		// provider's method. db.users.length() reaches here as length(db.users)
+		// and means the table's row count, not the builtin's "length of a
+		// value"; the same collision hides find, filter, keys and set.
+		if result, handled, methodErr := i.callReceiverMethod(expr, env); handled {
+			return result, methodErr
+		}
 		return fn(i, expr.Args, env)
 	}
 
@@ -748,6 +821,20 @@ func (i *Interpreter) evaluateFunctionCall(expr FunctionCallExpr, env *Environme
 		// Call the method using reflection
 		// Capitalize first letter only, preserving camelCase (e.g., "countWhere" -> "CountWhere")
 		capitalizedName := capitalizeFirst(methodName)
+
+		// The receiver may not own this name at all: "hello".length() and
+		// input.email.contains("@") are the builtins' work, and reflection can
+		// only report that a string has no such method. Falling back keeps
+		// obj.method(a) and method(obj, a) meaning the same thing, which is the
+		// other half of the collision callReceiverMethod handles.
+		if !HasMethod(obj, capitalizedName) {
+			if fn, ok := builtinFuncs[methodName]; ok {
+				segments := strings.Split(expr.Name, ".")
+				receiver := receiverExprFromPath(segments[:len(segments)-1])
+				return fn(i, append([]Expr{receiver}, expr.Args...), env)
+			}
+		}
+
 		return CallMethod(obj, capitalizedName, args...)
 	}
 

--- a/pkg/server/router.go
+++ b/pkg/server/router.go
@@ -67,11 +67,24 @@ func (r *Router) Match(method HTTPMethod, path string) (*Route, map[string]strin
 
 	pathSegments := splitPath(path)
 
-	// Try to match routes in order
+	// Prefer the most specific match rather than the first registered one. A
+	// route captures fewer segments as parameters the more specific it is, so
+	// /api/posts/published wins over /api/posts/:id no matter which was
+	// declared first - otherwise declaring the parameter route earlier makes
+	// the static one unreachable. Equal specificity keeps declaration order.
+	var best *RouteNode
+	var bestParams map[string]string
 	for _, node := range routes {
-		if params, matched := matchRoute(node, pathSegments); matched {
-			return node.route, params, nil
+		params, matched := matchRoute(node, pathSegments)
+		if !matched {
+			continue
 		}
+		if best == nil || len(params) < len(bestParams) {
+			best, bestParams = node, params
+		}
+	}
+	if best != nil {
+		return best.route, bestParams, nil
 	}
 
 	return nil, nil, fmt.Errorf("no route matches path %s", path)

--- a/tests/examples_runtime_test.go
+++ b/tests/examples_runtime_test.go
@@ -26,19 +26,12 @@ import (
 // fails. They are skipped so this test can guard the 14 that work; an entry
 // here is coverage we do not have yet, not a route that is fine.
 //
-// Three themes, none of them a wiring problem: examples calling functions that
-// do not exist, examples reading a query parameter that was not supplied, and
-// examples returning objects missing a required field.
+// What is left is not examples calling things that were never meant to exist.
+// Both remaining entries are surfaces the project documents and does not
+// implement, which is the same shape as the providers that shipped unwired.
 var knownBroken = map[string]string{
-	"mongodb-demo":      "mongo.Collection(x).InsertOne(y): chained provider calls are not dispatched",
-	"auth-demo":         "GET /api/auth/me returns an object missing the required field id",
-	"blog-api":          "calls paginate(), which is not a builtin",
-	"blog-api-complete": "calls timestamp(), which is not a builtin",
-	"e-commerce-api":    "calls timestamp(), which is not a builtin",
-	"macros-demo":       "calls db.insert(), which the database provider does not expose",
-	"cart-api":          "calls filter() with 3 arguments; it takes 2 (array, function)",
-	"feature-showcase":  "calls filter() with 3 arguments; it takes 2 (array, function)",
-	"database-demo":     "calls length() on a table handler rather than a collection",
+	"mongodb-demo":     "mongo.Collection(x).InsertOne(y): chained provider calls are not dispatched",
+	"feature-showcase": "reads ws.get_rooms(); the ws object is documented in LANGUAGE_SPECIFICATION.md but is never bound into a route, and the hub has no rooms or uptime to report",
 }
 
 var paramFreeGetRoute = regexp.MustCompile(`(?m)^@\s+GET\s+(/[^\s:{]*)\s*(->[^{]*)?\{`)

--- a/tests/symbols_runtime_test.go
+++ b/tests/symbols_runtime_test.go
@@ -275,6 +275,74 @@ func TestSymbolProviderInjection(t *testing.T) {
 	}
 }
 
+// TestBuiltinAndProviderMethodsCoexist covers names the builtins and the
+// providers both use. The parser rewrites obj.method(a) into method(obj, a),
+// so db.users.length() and length("hello") arrive at the same place under the
+// same name and each has to reach the right implementation. Before this, the
+// builtin won every time and a table's length() failed with "length() expects
+// a string, array, or object argument, got *database.MockTableHandler", while
+// the reverse path made "hello".length() fail with "method Length not found on
+// type string".
+func TestBuiltinAndProviderMethodsCoexist(t *testing.T) {
+	if testing.Short() {
+		t.Skip("boots a server; skipped in -short")
+	}
+
+	request, logs := serve(t, buildGlyphBinary(t), `@ GET /counts {
+  % db: Database
+  $ text = "hello"
+  $ list = [3, 1, 2]
+  > {
+    tableRows: db.rows.length(),
+    stringLen: text.length(),
+    listLen: list.length(),
+    upper: text.upper(),
+    has: text.contains("ell")
+  }
+}`)
+
+	status, body := request("GET", "/counts", "")
+	if status != http.StatusOK {
+		t.Fatalf("route failed: got %d %s\nserver log:\n%s", status, body, logs())
+	}
+	for _, want := range []string{
+		`"tableRows":0`, // the provider's method, not the builtin
+		`"stringLen":5`, // the builtin, not the provider's
+		`"listLen":3`,
+		`"upper":"HELLO"`,
+		`"has":true`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("missing %s in response: %s", want, body)
+		}
+	}
+}
+
+// TestRouteMatchPrefersStaticSegment covers @ when two routes can match the
+// same path. Matching used to take the first route registered, so declaring
+// /posts/:id before /posts/published made the second unreachable: the request
+// ran the parameter route with id="published".
+func TestRouteMatchPrefersStaticSegment(t *testing.T) {
+	if testing.Short() {
+		t.Skip("boots a server; skipped in -short")
+	}
+
+	request, _ := serve(t, buildGlyphBinary(t), `@ GET /posts/:id {
+  > {matched: "param", id: id}
+}
+
+@ GET /posts/published {
+  > {matched: "static"}
+}`)
+
+	if _, body := request("GET", "/posts/published", ""); !strings.Contains(body, `"matched":"static"`) {
+		t.Errorf("static route lost to the parameter route declared before it: %s", body)
+	}
+	if _, body := request("GET", "/posts/7", ""); !strings.Contains(body, `"matched":"param"`) {
+		t.Errorf("parameter route stopped matching: %s", body)
+	}
+}
+
 // TestSymbolCommand covers ! by invoking a declared command through
 // `glyph exec`, which needs no server.
 func TestSymbolCommand(t *testing.T) {


### PR DESCRIPTION
Part 3, the last of the sweep. These were filed as "examples calling functions that do not exist". Most of them called functions that do exist and could not reach them.

## Builtins were shadowing provider methods

The parser rewrites `obj.method(a)` into `method(obj, a)`, and `evaluateFunctionCall` consulted the builtin table before the receiver. Any provider method sharing a builtin's name was therefore unreachable:

```
db.users.length()  ->  length() expects a string, array, or object argument,
                       got *database.MockTableHandler
```

`MockTableHandler.Length()` existed the whole time, and `Length` was already on the whitelist. The same collision hides `find`, `filter`, `keys` and `set`.

The reverse path had the identical hole from the other side. `obj.method()` went to reflection with no fallback, so the builtin was unreachable from method position:

```
"hello".length()   ->  method Length not found on type string
length("hello")    ->  5
```

Both directions now resolve to whichever implementation owns the name. The method whitelist still decides first, so a builtin's name cannot become a route to an unlisted method, and only plain references are probed as receivers - discovering the type of `length(db.users.all())` must not run the query twice.

That single fix cleared the `length()` and `filter()` entries.

## Route matching took the first route, not the most specific

```
@ GET /api/posts/:id        <- declared line 89
@ GET /api/posts/published  <- declared line 324, unreachable
```

`/api/posts/published` ran the parameter route with `id="published"`. Matching now prefers the candidate that captures fewest segments as parameters; equal specificity keeps declaration order. This is why `blog-api` failed, and it would silently mis-route any program that declares a parameter route before a static sibling.

## The genuinely missing operations were rewritten, not added

Per the decision on this one: keep the surface as it is, and let the examples describe what the language actually does. Notably this keeps raw SQL out of the language rather than committing to an escape hatch that needs its own injection story.

- `timestamp()` is `now()`, which already existed and returns the same thing. `timestamp` is also a type name, so a function of that name would have read badly.
- `db.posts.paginate(offset, n)` is `all()` plus `slice()`.
- `macros-demo` uses `db.users.create/.all/.get/.delete` instead of `db.query("SELECT ...")` and `db.insert("users", input)`. Those routes also never injected the provider they used, so they were compiled rather than interpreted.
- `blog-api` returned a not-found object that could not satisfy its declared `PostWithComments` return type; a guard is what that is for. It also called `sortBy()`, which exists nowhere - not a builtin, not a handler method.

## Two entries were stale

`auth-demo` and `cart-api` pass now and described failures that no longer happen. Their reasons went out of date when earlier parts of the sweep landed, which is the argument for the reasons being specific enough to expire visibly.

## What remains, and why it is not in here

Both surviving entries are documented surfaces with no implementation, not examples at fault:

- `mongodb-demo` - chained provider calls (`mongo.Collection(x).InsertOne(y)`), tracked separately by the plan.
- `feature-showcase` - `ws.get_rooms()`. `LANGUAGE_SPECIFICATION.md` and `API_REFERENCE.md` document nine `ws` methods. The object is never bound into a route, and the hub has no rooms or uptime to report - it has `GetConnectionCount` and nothing else the docs promise. Implementing it or correcting the docs is a real decision and wants its own change.

## Verification

- `TestBuiltinAndProviderMethodsCoexist` asserts a table's `length()` and a string's `length()` both reach the right implementation in one route; `TestRouteMatchPrefersStaticSegment` declares the parameter route first on purpose. Both fail when reverted: 500, and `{"id":"published","matched":"param"}`.
- The examples harness passes with 7 entries removed, down from 9 to 2 (this branch predates #313, so the four query-parameter entries are still listed here and go when that merges).
- All 31 examples validate; `gofmt`, `go vet ./...`, full `go test ./...` clean.
