### PR TITLE
fix: make GLYPH_PORT real, and drop the two env vars that were not

### DIFF
--- a/cmd/glyph/cli_coverage_test.go
+++ b/cmd/glyph/cli_coverage_test.go
@@ -527,3 +527,49 @@ func TestRunAutoDetectBytecode(t *testing.T) {
 	err = runRun(runCmd, []string{compiledFile})
 	require.NoError(t, err)
 }
+
+// TestResolvePort covers the precedence between --port, GLYPH_PORT and the
+// compiled-in default. GLYPH_PORT was documented in docs/CLI.md, the
+// deployment guide and the Kubernetes manifest long before anything read it,
+// so setting it silently did nothing.
+func TestResolvePort(t *testing.T) {
+	newCmd := func(flag string) *cobra.Command {
+		cmd := &cobra.Command{}
+		cmd.Flags().Uint16("port", 3000, "")
+		if flag != "" {
+			require.NoError(t, cmd.Flags().Set("port", flag))
+		}
+		return cmd
+	}
+
+	t.Run("default when neither is given", func(t *testing.T) {
+		t.Setenv("GLYPH_PORT", "")
+		port, err := resolvePort(newCmd(""))
+		require.NoError(t, err)
+		assert.Equal(t, uint16(3000), port)
+	})
+
+	t.Run("environment applies when the flag is absent", func(t *testing.T) {
+		t.Setenv("GLYPH_PORT", "9001")
+		port, err := resolvePort(newCmd(""))
+		require.NoError(t, err)
+		assert.Equal(t, uint16(9001), port)
+	})
+
+	t.Run("explicit flag beats the environment", func(t *testing.T) {
+		t.Setenv("GLYPH_PORT", "9001")
+		port, err := resolvePort(newCmd("9002"))
+		require.NoError(t, err)
+		assert.Equal(t, uint16(9002), port)
+	})
+
+	// A typo must not quietly serve somewhere else.
+	for _, bad := range []string{"abc", "0", "99999", "-1", "8080x"} {
+		t.Run("rejects "+bad, func(t *testing.T) {
+			t.Setenv("GLYPH_PORT", bad)
+			_, err := resolvePort(newCmd(""))
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "GLYPH_PORT")
+		})
+	}
+}

--- a/cmd/glyph/commands.go
+++ b/cmd/glyph/commands.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"time"
 
 	"github.com/fatih/color"
@@ -16,6 +17,35 @@ import (
 	"github.com/glyphlang/glyph/pkg/vm"
 	"github.com/spf13/cobra"
 )
+
+// envPort names the port to listen on when --port is not given. It sits
+// alongside GLYPH_HOST: between them the listen address is configurable without
+// a command line, which is what a container or a service manager needs.
+const envPort = "GLYPH_PORT"
+
+// resolvePort returns the port to listen on: an explicit --port wins, then
+// GLYPH_PORT, then the compiled-in default.
+//
+// A GLYPH_PORT that is not a usable port fails the command rather than falling
+// back. Serving on a different port than the operator asked for, and saying
+// nothing, is the failure this sweep has spent its time removing.
+func resolvePort(cmd *cobra.Command) (uint16, error) {
+	port, _ := cmd.Flags().GetUint16("port")
+	if cmd.Flags().Changed("port") {
+		return port, nil
+	}
+
+	raw, set := os.LookupEnv(envPort)
+	if !set || raw == "" {
+		return port, nil
+	}
+
+	parsed, err := strconv.ParseUint(raw, 10, 16)
+	if err != nil || parsed == 0 {
+		return 0, fmt.Errorf("%s=%q is not a port between 1 and 65535", envPort, raw)
+	}
+	return uint16(parsed), nil
+}
 
 // runCompile handles the compile command
 func runCompile(cmd *cobra.Command, args []string) error {
@@ -254,7 +284,10 @@ func runTest(cmd *cobra.Command, args []string) error {
 
 func runRun(cmd *cobra.Command, args []string) error {
 	filePath := args[0]
-	port, _ := cmd.Flags().GetUint16("port")
+	port, err := resolvePort(cmd)
+	if err != nil {
+		return err
+	}
 	useBytecode, _ := cmd.Flags().GetBool("bytecode")
 	useInterpreter, _ := cmd.Flags().GetBool("interpret")
 
@@ -303,7 +336,10 @@ func runRun(cmd *cobra.Command, args []string) error {
 // runDev handles the dev command
 func runDev(cmd *cobra.Command, args []string) error {
 	filePath := args[0]
-	port, _ := cmd.Flags().GetUint16("port")
+	port, err := resolvePort(cmd)
+	if err != nil {
+		return err
+	}
 	watch, _ := cmd.Flags().GetBool("watch")
 	openBrowser, _ := cmd.Flags().GetBool("open")
 

--- a/deploy/DEPLOYMENT_GUIDE.md
+++ b/deploy/DEPLOYMENT_GUIDE.md
@@ -37,7 +37,7 @@ docker build -t glyph:latest .
 docker run -d \
   --name glyph-app \
   -p 8080:8080 \
-  -e Glyph_ENV=production \
+  -e GLYPH_PORT=8080 \
   -e DATABASE_URL=postgresql://user:pass@postgres:5432/db \
   glyph:latest
 ```
@@ -61,9 +61,7 @@ docker run -it \
 | Variable | Description | Default |
 |----------|-------------|---------|
 | `GLYPH_HOST` | Interface to bind. Must be `0.0.0.0` to be reachable from outside the container; the shipped Dockerfiles set it | `127.0.0.1` |
-| `Glyph_ENV` | Environment (development/production) | production |
-| `Glyph_PORT` | HTTP server port | 8080 |
-| `Glyph_LOG_LEVEL` | Log level (debug/info/warn/error) | info |
+| `GLYPH_PORT` | Port to listen on. `--port` takes precedence, and the shipped image passes it explicitly | 3000 |
 | `DATABASE_URL` | PostgreSQL connection string | - |
 | `REDIS_URL` | Redis connection string | - |
 

--- a/deploy/kubernetes/deployment.yaml
+++ b/deploy/kubernetes/deployment.yaml
@@ -40,12 +40,9 @@ spec:
         # Service can reach.
         - name: GLYPH_HOST
           value: "0.0.0.0"
-        - name: Glyph_ENV
-          value: "production"
-        - name: Glyph_PORT
+        # Must agree with containerPort above and with the probe ports below.
+        - name: GLYPH_PORT
           value: "8080"
-        - name: Glyph_LOG_LEVEL
-          value: "info"
         - name: DATABASE_URL
           valueFrom:
             secretKeyRef:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,9 +10,9 @@ services:
     ports:
       - "8080:8080"
     environment:
-      - Glyph_ENV=production
-      - Glyph_PORT=8080
-      - Glyph_LOG_LEVEL=info
+      # The image binds all interfaces; GLYPH_PORT must match the mapping above.
+      - GLYPH_HOST=0.0.0.0
+      - GLYPH_PORT=8080
     volumes:
       # Mount your GlyphLang application
       - ./examples:/app/examples:ro

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -969,9 +969,11 @@ GlyphLang applications can be configured via environment variables.
 | Variable | Description | Default |
 |----------|-------------|---------|
 | `GLYPH_HOST` | Interface `glyph run` and `glyph dev` bind to. Set to `0.0.0.0` to serve other machines, as containers must | `127.0.0.1` |
-| `Glyph_ENV` | Environment (development/production) | `production` |
-| `Glyph_PORT` | HTTP server port | `8080` |
-| `Glyph_LOG_LEVEL` | Log level (debug/info/warn/error) | `info` |
+| `GLYPH_PORT` | Port to listen on. `--port` takes precedence; a value that is not a port between 1 and 65535 fails the command rather than falling back | `3000` |
+
+`Glyph_ENV` and `Glyph_LOG_LEVEL` were listed here but were never read by
+anything, so setting them had no effect. They have been removed rather than
+left to imply configuration that does not exist.
 
 ### Database Variables
 
@@ -992,9 +994,8 @@ GlyphLang applications can be configured via environment variables.
 
 ```bash
 # Application
-Glyph_ENV=production
-Glyph_PORT=8080
-Glyph_LOG_LEVEL=info
+GLYPH_HOST=0.0.0.0
+GLYPH_PORT=8080
 
 # Database
 DATABASE_URL=postgres://glyph:secret@localhost:5432/glyphdb
@@ -1011,7 +1012,7 @@ OTEL_EXPORTER_OTLP_ENDPOINT=jaeger:4317
 source .env && glyph run main.glyph
 
 # Or export directly
-export Glyph_PORT=3000
+export GLYPH_PORT=3000
 export DATABASE_URL="postgres://..."
 glyph run main.glyph
 ```


### PR DESCRIPTION
`docs/CLI.md`, `deploy/DEPLOYMENT_GUIDE.md`, `docker-compose.yml` and `deploy/kubernetes/deployment.yaml` all documented `Glyph_ENV`, `Glyph_PORT` and `Glyph_LOG_LEVEL`. None of the three appeared anywhere in the Go source.

`Glyph_PORT` is the one that bites. An operator setting it in a manifest got the default port, no warning, and a config block that reads as though it did something. The casing was wrong too - every variable the code actually reads is `GLYPH_*`.

## GLYPH_PORT

```
$ glyph run app.glyph                          -> 127.0.0.1:3000   (default)
$ GLYPH_PORT=9001 glyph run app.glyph          -> 127.0.0.1:9001
$ GLYPH_PORT=9001 glyph run app.glyph -p 9002  -> 127.0.0.1:9002   (flag wins)
```

An unusable value fails the command rather than falling back:

```
$ GLYPH_PORT=abc glyph run app.glyph
Error: GLYPH_PORT="abc" is not a port between 1 and 65535
```

Silently serving somewhere other than where the operator asked is the same failure this sweep has been clearing, so a typo is loud. `0`, `99999` and `-1` are rejected the same way.

## The other two are removed, not implemented

Neither `Glyph_ENV` nor `Glyph_LOG_LEVEL` had semantics defined anywhere. `pkg/logging` exists with levels but is not wired to the server or the CLI at all - `cmd/glyph` uses its own `printInfo`/`printWarning` and `loggingMiddleware`. Implementing `GLYPH_LOG_LEVEL` therefore means deciding what logging should be, which is a feature rather than a config fix, and inventing it here would be exactly the "documented, then made real to match" move this project has been paying for.

They are gone from the docs and manifests, with a line in `docs/CLI.md` saying they were never read, so anyone who set them learns why it did nothing.

## Also

The documented default said `8080`; `config.DefaultPort` has been `3000`. Corrected.

## Verification

- `TestResolvePort` covers all three precedence cases and five rejected values.
- `gofmt`, `go vet ./...`, full `go test ./...` clean.
- Verified against a running server for default, env, and flag-beats-env.
- No `Glyph_ENV`/`Glyph_PORT`/`Glyph_LOG_LEVEL` references remain outside the note explaining their removal.

Two decisions from this sweep were also written up in `DECISIONS.md` (git-ignored, so not in this diff): the loopback bind default, and rewriting examples rather than growing the API.
